### PR TITLE
Add MetaTestResult

### DIFF
--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
@@ -8,6 +8,7 @@ import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.grade.GradeCalculator;
+import nl.tudelft.cse1110.andy.result.MetaTestResult;
 import nl.tudelft.cse1110.andy.result.Result;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.utils.FilesUtils;
@@ -40,8 +41,7 @@ public class RunMetaTestsStep implements ExecutionStep {
             String originalLibraryContent = readFile(libraryFile);
 
             List<MetaTest> metaTests = runCfg.metaTests();
-            List<String> failures = new ArrayList<>();
-            List<String> passes = new ArrayList<>();
+            List<MetaTestResult> metaTestResults = new ArrayList<>();
 
             /*
              * For each meta test, we basically perform a string replace in the
@@ -71,11 +71,9 @@ public class RunMetaTestsStep implements ExecutionStep {
 
                 if (passesTheMetaTest) {
                     score+= metaTest.getWeight();
-                    String metaName = metaTest.getNameAndWeight();
-                    passes.add(metaName);
+                    metaTestResults.add(new MetaTestResult(metaTest.getName(), metaTest.getWeight(), true));
                 } else {
-                    String metaName = metaTest.getNameAndWeight();
-                    failures.add(metaName);
+                    metaTestResults.add(new MetaTestResult(metaTest.getName(), metaTest.getWeight(), false));
                 }
 
                 /* Clean up the directory */
@@ -83,7 +81,7 @@ public class RunMetaTestsStep implements ExecutionStep {
             }
 
             int totalWeight = metaTests.stream().mapToInt(m -> m.getWeight()).sum();
-            result.logMetaTests(score, totalWeight, passes, failures);
+            result.logMetaTests(score, totalWeight, metaTestResults);
         } catch (Exception ex) {
             result.genericFailure(this, ex);
         } finally {

--- a/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestResult.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestResult.java
@@ -1,0 +1,25 @@
+package nl.tudelft.cse1110.andy.result;
+
+public class MetaTestResult {
+    private final String name;
+    private final int weight;
+    private final boolean passed;
+
+    public MetaTestResult(String name, int weight, boolean passed) {
+        this.name = name;
+        this.weight = weight;
+        this.passed = passed;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getWeight() {
+        return weight;
+    }
+
+    public boolean isPassed() {
+        return passed;
+    }
+}

--- a/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestsResult.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestsResult.java
@@ -7,29 +7,27 @@ public class MetaTestsResult {
     private final boolean wasExecuted;
     private final int score;
     private final int totalTests;
-    private final List<String> passes;
-    private final List<String> failures;
+    private final List<MetaTestResult> metaTestResults;
 
-    private MetaTestsResult(boolean wasExecuted, int score, int totalTests, List<String> passes, List<String> failures) {
+    private MetaTestsResult(boolean wasExecuted, int score, int totalTests, List<MetaTestResult> metaTestResults) {
         this.wasExecuted = wasExecuted;
         this.score = score;
         this.totalTests = totalTests;
-        this.passes = passes;
-        this.failures = failures;
+        this.metaTestResults = metaTestResults;
 
-        if(this.passes.size() + this.failures.size() > this.totalTests)
+        if(this.metaTestResults.size() > this.totalTests)
             throw new RuntimeException("Number of meta tests do not match.");
 
         if(this.score > this.totalTests)
             throw new RuntimeException("Meta tests score greater than maximum.");
     }
 
-    public static MetaTestsResult build(int score, int totalTests, List<String> passes, List<String> failures) {
-        return new MetaTestsResult(true, score, totalTests, passes, failures);
+    public static MetaTestsResult build(int score, int totalTests, List<MetaTestResult> metaTestResults) {
+        return new MetaTestsResult(true, score, totalTests, metaTestResults);
     }
 
     public static MetaTestsResult empty() {
-        return new MetaTestsResult(false, 0, 0, Collections.emptyList(), Collections.emptyList());
+        return new MetaTestsResult(false, 0, 0, Collections.emptyList());
     }
 
     public int getPassedMetaTests() {
@@ -40,12 +38,8 @@ public class MetaTestsResult {
         return totalTests;
     }
 
-    public List<String> getPasses() {
-        return Collections.unmodifiableList(passes);
-    }
-
-    public List<String> getFailures() {
-        return Collections.unmodifiableList(failures);
+    public List<MetaTestResult> getMetaTestResults() {
+        return Collections.unmodifiableList(metaTestResults);
     }
 
     public boolean wasExecuted() {

--- a/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
@@ -214,8 +214,8 @@ public class ResultBuilder {
     /*
      * Meta tests
      */
-    public void logMetaTests(int score, int totalTests, List<String> passes, List<String> failures) {
-        this.metaTestResults = MetaTestsResult.build(score, totalTests, passes, failures);
+    public void logMetaTests(int score, int totalTests, List<MetaTestResult> metaTestResults) {
+        this.metaTestResults = MetaTestsResult.build(score, totalTests, metaTestResults);
     }
 
     /*

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -191,11 +191,12 @@ public class WebLabResultWriter implements ResultWriter {
         l(String.format("%d/%d passed", metaTests.getPassedMetaTests(), metaTests.getTotalTests()));
 
         if (allHints) {
-            for (String pass : metaTests.getPasses()) {
-                l(String.format("Meta test: %s PASSED", pass));
-            }
-            for (String failure : metaTests.getFailures()) {
-                l(String.format("Meta test: %s FAILED", failure));
+            for (MetaTestResult metaTestResult : metaTests.getMetaTestResults()) {
+                if (metaTestResult.isPassed()) {
+                    l(String.format("Meta test: %s (weight: %d) PASSED", metaTestResult.getName(), metaTestResult.getWeight()));
+                } else {
+                    l(String.format("Meta test: %s (weight: %d) FAILED", metaTestResult.getName(), metaTestResult.getWeight()));
+                }
             }
         }
 


### PR DESCRIPTION
The analytics application stores a meta test by its name and weight. In order to send meta test results in a form that the analytics application wants, I added `MetaTestResult` and pass a list of `MetaTestResult`s to `MetaTestsResult` instead of two lists of strings.