### PR TITLE
Make `Andy` accept command line arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,13 @@
             <version>3.2.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/commons-cli/commons-cli -->
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/nl/tudelft/cse1110/andy/Andy.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/Andy.java
@@ -1,5 +1,6 @@
 package nl.tudelft.cse1110.andy;
 
+import com.google.common.io.Files;
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
@@ -9,32 +10,93 @@ import nl.tudelft.cse1110.andy.writer.weblab.RandomAsciiArtGenerator;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
 import nl.tudelft.cse1110.andy.writer.weblab.WebLabResultWriter;
+import org.apache.commons.cli.*;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static nl.tudelft.cse1110.andy.utils.FilesUtils.*;
 
 public class Andy {
 
-    public static void main(String[] args) {
-        if (System.getenv("ACTION") == null || System.getenv("WORKING_DIR") == null || System.getenv("OUTPUT_DIR") == null) {
-            System.out.println("Missing configuration.");
-            System.exit(-1);
-        }
+    private static final CommandLineParser parser = new DefaultParser();
+    private static final Options options          = new Options();
+    private static File temporaryDirectory        = null;
 
-        Context ctx = buildContext();
+    public static void main(String[] args) throws Exception {
+        Context ctx = (args.length > 0)
+                ? buildContextWithCommandLineArguments(args)
+                : buildContextWithEnvironmentVariables();
 
         ResultBuilder result = new ResultBuilder(ctx, new GradeCalculator());
         ResultWriter writer = new WebLabResultWriter(ctx, new RandomAsciiArtGenerator());
         ExecutionFlow flow = ExecutionFlow.build(ctx, result, writer);
 
         flow.run();
+
+        System.out.println(readFile(new File(concatenateDirectories(ctx.getDirectoryConfiguration().getOutputDir(), "stdout.txt"))));
+
+        /* Remove the temporary directory, if one was created. */
+        if (temporaryDirectory != null) {
+            FileUtils.deleteDirectory(temporaryDirectory);
+        }
     }
 
-    private static Context buildContext() {
-        Action action = Action.valueOf(System.getenv("ACTION"));
+    private static Context buildContextWithCommandLineArguments(String[] args) throws Exception {
+        options.addOption("e", "exercise", true, "Exercise name in the assignments repo.");
+        options.addOption("d", "directory", true, "Base directory of the exercise");
+        options.addOption("o", "output", true, "Output directory of the exercise");
+        options.addOption("f", "full-with-hints", false, "Run Andy completely");
+        options.addOption("F", "full-without-hints", false, "Run Andy without hints");
+        options.addOption("c", "coverage", false, "Run Andy with only coverage");
+        options.addOption("t", "tests", false, "Run Andy only with tests");
+        options.addOption("T", "meta-tests", false, "Run Andy only with meta tests");
+
+        CommandLine cmd = parser.parse(options, args);
+        if (cmd.hasOption('e')) return buildContext(cmd);
+        if (!cmd.hasOption('d')) { System.out.println("Error: no base directory supplied, please use the flag -d.");   System.exit(-1); }
+        if (!cmd.hasOption('o')) { System.out.println("Error: no output directory supplied, please use the flag -o."); System.exit(-1); }
+
+        return buildContext(cmd);
+    }
+
+    private static Context buildContextWithEnvironmentVariables() throws Exception {
+        if (System.getenv("ACTION")      == null) { System.out.println("No ACTION environment variable.");      System.exit(-1); }
+        if (System.getenv("WORKING_DIR") == null) { System.out.println("No WORKING_DIR environment variable."); System.exit(-1); }
+        if (System.getenv("OUTPUT_DIR")  == null) { System.out.println("No OUTPUT_DIR environment variable.");  System.exit(-1); }
+
+        return buildContext(null);
+    }
+
+    private static Context buildContext(CommandLine cmd) throws FileNotFoundException {
+        Action action = (cmd == null) ? Action.valueOf(System.getenv("ACTION"))
+                : cmd.hasOption('f') ? Action.FULL_WITH_HINTS
+                : cmd.hasOption('F') ? Action.FULL_WITHOUT_HINTS
+                : cmd.hasOption('c') ? Action.COVERAGE
+                : cmd.hasOption('T') ? Action.META_TEST
+                : Action.TESTS;
         Context ctx = new Context(action);
 
-        DirectoryConfiguration dirCfg = new DirectoryConfiguration(
-                System.getenv("WORKING_DIR"),
-                System.getenv("OUTPUT_DIR")
-        );
+        DirectoryConfiguration dirCfg;
+        if (cmd == null) {
+            dirCfg = new DirectoryConfiguration(System.getenv("WORKING_DIR"), System.getenv("OUTPUT_DIR"));
+        } else {
+            temporaryDirectory  = Files.createTempDir();
+
+            /* Move all the files over to the temporary directory. */
+            String workDir = (cmd.hasOption('e'))
+                    ? System.getProperty("user.dir") + "/output/" + cmd.getOptionValue('e')
+                    : cmd.getOptionValue('d');
+            copyFile(findLibrary(workDir), temporaryDirectory.getAbsolutePath());
+            copyFile(findSolution(workDir), temporaryDirectory.getAbsolutePath());
+            copyFile(findConfiguration(workDir), temporaryDirectory.getAbsolutePath());
+
+            dirCfg = (cmd.hasOption('e'))
+                   ? new DirectoryConfiguration(temporaryDirectory.getAbsolutePath(), System.getProperty("user.dir") + "/output/" + cmd.getOptionValue('e'))
+                   : new DirectoryConfiguration(temporaryDirectory.getAbsolutePath(), cmd.getOptionValue('o'));
+        }
+
         ctx.setDirectoryConfiguration(dirCfg);
 
         return ctx;

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/OrganizeSourceCodeStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/OrganizeSourceCodeStep.java
@@ -4,6 +4,7 @@ import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
+import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -21,8 +22,10 @@ public class OrganizeSourceCodeStep implements ExecutionStep {
         DirectoryConfiguration dirCfg = ctx.getDirectoryConfiguration();
 
         try {
-            List<String> listOfFiles = filePathsAsString(getAllJavaFiles(dirCfg.getWorkingDir()));
+            /* Delete the output directory since it will be newly generated. */
+            FileUtils.deleteDirectory(new File(dirCfg.getOutputDir()));
 
+            List<String> listOfFiles = filePathsAsString(getAllJavaFiles(dirCfg.getWorkingDir()));
             for(String pathOfJavaClass : listOfFiles) {
                 String content = new String(Files.readAllBytes(Paths.get(pathOfJavaClass)));
 

--- a/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunCodeChecksStep.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunCodeChecksStep.java
@@ -7,6 +7,8 @@ import nl.tudelft.cse1110.andy.config.RunConfiguration;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 
+import java.io.FileNotFoundException;
+
 import static nl.tudelft.cse1110.andy.utils.FilesUtils.findSolution;
 
 public class RunCodeChecksStep implements ExecutionStep {
@@ -16,9 +18,12 @@ public class RunCodeChecksStep implements ExecutionStep {
         RunConfiguration runCfg = ctx.getRunConfiguration();
 
         CheckScript script = runCfg.checkScript();
-        script.runChecks(findSolution(dirCfg.getWorkingDir()));
-
-        result.logCodeChecks(script);
+        try {
+            script.runChecks(findSolution(dirCfg.getWorkingDir()));
+            result.logCodeChecks(script);
+        } catch (Exception e) {
+            result.genericFailure(this, e);
+        }
     }
 
     @Override

--- a/src/main/java/nl/tudelft/cse1110/andy/grade/GradeWeight.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/grade/GradeWeight.java
@@ -39,10 +39,10 @@ public class GradeWeight {
     }
 
     public static GradeWeight fromConfig(Map<String, Float> weights) {
-        float coverage = weights.get("coverage");
-        float mutation = weights.get("mutation");
-        float meta = weights.get("meta");
-        float codechecks = weights.get("codechecks");
+        float coverage   = weights.getOrDefault("coverage",   0.0f);
+        float mutation   = weights.getOrDefault("mutation",   0.0f);
+        float meta       = weights.getOrDefault("meta",       0.0f);
+        float codechecks = weights.getOrDefault("codechecks", 0.0f);
 
         return new GradeWeight(coverage, mutation, meta, codechecks);
     }

--- a/src/main/java/nl/tudelft/cse1110/andy/utils/FilesUtils.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/utils/FilesUtils.java
@@ -1,9 +1,11 @@
 package nl.tudelft.cse1110.andy.utils;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -71,22 +73,33 @@ public class FilesUtils {
         return dir1 + (dir1.endsWith("/")?"":"/") + dir2;
     }
 
-    public static String findSolution(String workdir) {
+    public static String findSolution(String workdir) throws FileNotFoundException {
         return getAllJavaFiles(workdir)
-                .stream().filter(x -> x.getAbsolutePath().endsWith("Solution.java"))
+                .stream().filter(x -> x.getAbsolutePath().endsWith("Solution.java")
+                        || x.getAbsolutePath().contains("Test"))
                 .map(x -> x.getAbsolutePath())
                 .findFirst()
-                .get();
+                .orElseThrow(() -> new FileNotFoundException("Solution file does not exist."));
     }
 
-    public static String findLibrary(String workdir) {
+    public static String findLibrary(String workdir) throws FileNotFoundException {
         return getAllJavaFiles(workdir)
-                .stream().filter(x -> x.getAbsolutePath().endsWith("Library.java"))
+                .stream().filter(x -> x.getAbsolutePath().endsWith("Library.java")
+                        || (!x.getAbsolutePath().contains("Test") &&
+                            !x.getAbsolutePath().endsWith("Solution.java") &&
+                            !x.getAbsolutePath().endsWith("Configuration.java")))
                 .map(x -> x.getAbsolutePath())
                 .findFirst()
-                .get();
+                .orElseThrow(() -> new FileNotFoundException("Library file does not exist."));
     }
 
+    public static String findConfiguration(String workdir) throws FileNotFoundException {
+        return getAllJavaFiles(workdir)
+                .stream().filter(x -> x.getAbsolutePath().endsWith("Configuration.java"))
+                .map(x -> x.getAbsolutePath())
+                .findFirst()
+                .orElseThrow(() -> new FileNotFoundException("Configuration file does not exist."));
+    }
 
     public static Path createTemporaryDirectory(String prefix) {
         try {

--- a/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/RandomAsciiArtGenerator.java
+++ b/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/RandomAsciiArtGenerator.java
@@ -23,7 +23,6 @@ public class RandomAsciiArtGenerator {
     private File pickRandomAsciiArtFile() {
 
         String asciiDirPath = ResourceUtils.resourceFolder("congrats");
-        System.out.println(asciiDirPath);
         File asciiDir = new File(asciiDirPath);
 
         File[] listOfAscii = FilesUtils.getAllFiles(asciiDir);

--- a/src/test/java/integration/IntegrationTestBase.java
+++ b/src/test/java/integration/IntegrationTestBase.java
@@ -1,5 +1,6 @@
 package integration;
 
+import com.google.common.io.Files;
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionFlow;
@@ -10,19 +11,24 @@ import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.utils.FilesUtils;
 import nl.tudelft.cse1110.andy.writer.EmptyWriter;
 import nl.tudelft.cse1110.andy.writer.ResultWriter;
-import org.junit.jupiter.api.io.TempDir;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
-import java.nio.file.Path;
+import java.io.IOException;
 
 import static nl.tudelft.cse1110.andy.utils.ResourceUtils.resourceFolder;
 
 public abstract class IntegrationTestBase {
-    @TempDir
-    protected Path reportDir;
 
-    @TempDir
-    protected Path workDir;
+    private final File workDir   = Files.createTempDir();
+    private final File reportDir = Files.createTempDir();
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        FileUtils.deleteDirectory(workDir);
+        FileUtils.deleteDirectory(reportDir);
+    }
 
     public Result run(Action action,
                       String libraryFile,


### PR DESCRIPTION
# Description
This PR adds an option to run `Andy` with command line arguments to ensure it would be able to be called correctly whenever packaged into a JAR file. This way it does not depend on the environment variables to be set since those are not easily changeable when calling it from another place than the IDE.

For this to be able to run correctly in a project, a clean up feature needed to be added such that once `Andy` is done the original file structure gets restored. So I added this in a `revertSourceCode` function after the `ExecutionFlow.run` method has been executed.

# Notes
This PR also adds some small changes in the `findLibrary` and `findSolution` to ensure the code also works when giving files a proper name instead of `Solution.java` and `Library.java`.