### PR TITLE
Fix Docker using an old branch version from cache

### DIFF
--- a/weblab-docker/Dockerfile
+++ b/weblab-docker/Dockerfile
@@ -19,10 +19,13 @@ SHELL ["/bin/bash", "-c"]
 # Copy the full repo to the docker image
 ARG ANDY_DIR=/home/andy/
 ARG ANDY_BRANCH=main
-RUN git clone -n https://github.com/SERG-Delft/andy.git && git -C ${ANDY_DIR} checkout ${ANDY_BRANCH}
+RUN git clone -n https://github.com/SERG-Delft/andy.git
+
+# Checkout the current branch
+WORKDIR ${ANDY_DIR}
+RUN git checkout ${ANDY_BRANCH}
 
 # Compile and install all dependencies
-WORKDIR ${ANDY_DIR}
 RUN mvn package -pl weblab-runner -am -Djar.finalName=andy -DskipTests
 
 ARG GNAME=student

--- a/weblab-docker/Dockerfile
+++ b/weblab-docker/Dockerfile
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 # Copy the full repo to the docker image
 ARG ANDY_DIR=/home/andy/
 ARG ANDY_BRANCH=main
-RUN git clone -n https://github.com/cse1110/andy.git && git -C ${ANDY_DIR} checkout ${ANDY_BRANCH}
+RUN git clone -n https://github.com/SERG-Delft/andy.git && git -C ${ANDY_DIR} checkout ${ANDY_BRANCH}
 
 # Compile and install all dependencies
 WORKDIR ${ANDY_DIR}

--- a/weblab-docker/Dockerfile
+++ b/weblab-docker/Dockerfile
@@ -16,9 +16,13 @@ RUN apt update \
 
 SHELL ["/bin/bash", "-c"]
 
-# Copy the full repo to the docker image
 ARG ANDY_DIR=/home/andy/
 ARG ANDY_BRANCH=main
+
+# Prevent Docker from using an old version of the branch from cache
+ADD "https://api.github.com/repos/SERG-Delft/andy/commits/${ANDY_BRANCH}?per_page=1" latest_commit
+
+# Copy the full repo to the docker image
 RUN git clone -n https://github.com/SERG-Delft/andy.git
 
 # Checkout the current branch


### PR DESCRIPTION
Docker was caching the `git clone` command, causing it to use an old branch version from cache. Fixed it by forcibly writing a file which changes every time a new commit is pushed (from the GitHub API), which should block the caching mechanism, as the image state would be different.