### PR TITLE
When running meta tests, we should skip Jacoco

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/InstrumentCodeForCoverageStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/InstrumentCodeForCoverageStep.java
@@ -4,6 +4,7 @@ import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.config.RunConfiguration;
 import nl.tudelft.cse1110.andy.execution.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
+import nl.tudelft.cse1110.andy.execution.mode.Action;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
 import nl.tudelft.cse1110.andy.utils.ClassUtils;
 import nl.tudelft.cse1110.andy.utils.FilesUtils;
@@ -43,6 +44,11 @@ public class InstrumentCodeForCoverageStep implements ExecutionStep {
 
         // Skip step if disabled
         if (ctx.getRunConfiguration().skipJacoco()) {
+            return;
+        }
+
+        // Skip step if running meta test
+        if (ctx.getAction().equals(Action.META_TEST)) {
             return;
         }
 


### PR DESCRIPTION
Solved issue #202 

I have checked the code and I think setting `skipJacoco` to true may be impossible (or too much hassle) since it is implemented as method that is overridden by user in config file.

This is the code that loads `RunConfiguration`
```
Class<?> runConfigurationClass = Class.forName(getConfigurationClass(ctx.getNewClassNames()), false, currentClassLoader);
RunConfiguration runConfiguration = (RunConfiguration) runConfigurationClass.getDeclaredConstructor().newInstance();
```

There is no easy way of overriding methods at runtime in Java. Therefore I think that second if in `InstrumentCodeForCoverageStep` is a simple and good solution. Which I have implemented in this branch
```
// Skip step if running meta test
        if (ctx.getAction().equals(Action.META_TEST)) {
            return;
        }
```