### PR TITLE
Reduce verbose test sysouts

### DIFF
--- a/andy/src/test/java/integration/JacocoTest.java
+++ b/andy/src/test/java/integration/JacocoTest.java
@@ -65,7 +65,7 @@ public class JacocoTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredBranches()).isEqualTo(14);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] coveredAndUncoveredLines")
     @MethodSource("coveredLinesGenerator")
     void coveredAndUncoveredLines(String library, String solution, List<Integer> coveredLines, List<Integer> partiallyCovered, List<Integer> notCovered) {
         Result result = run(Action.TESTS, library, solution);

--- a/andy/src/test/java/integration/assignments/AllAssignmentsTest.java
+++ b/andy/src/test/java/integration/assignments/AllAssignmentsTest.java
@@ -38,7 +38,7 @@ public class AllAssignmentsTest extends IntegrationTestBase {
                 configurationFile);
 
         assertThat(result.hasFailed()).as(format("exercise %s", directory)).isFalse();
-        assertThat(result.getFinalGrade()).as(format("ercise %s", directory)).isEqualTo(100);
+        assertThat(result.getFinalGrade()).as(format("exercise %s", directory)).isEqualTo(100);
     }
 
     private static Stream<Arguments> all() {

--- a/andy/src/test/java/integration/assignments/AllAssignmentsTest.java
+++ b/andy/src/test/java/integration/assignments/AllAssignmentsTest.java
@@ -38,7 +38,7 @@ public class AllAssignmentsTest extends IntegrationTestBase {
                 configurationFile);
 
         assertThat(result.hasFailed()).as(format("exercise %s", directory)).isFalse();
-        assertThat(result.getFinalGrade()).as(format("exercise %s", directory)).isEqualTo(100);
+        assertThat(result.getFinalGrade()).as(format("ercise %s", directory)).isEqualTo(100);
     }
 
     private static Stream<Arguments> all() {

--- a/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
+++ b/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LibraryMetaTestTest {
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] insertInLine")
     @MethodSource("insertInLineGenerator")
     void insertInLine(String oldCode, int lineToInsert, String contentToAdd, String expectedResult) {
         LibraryMetaTest metaTest = (LibraryMetaTest) MetaTest.insertAt("some meta test", lineToInsert, contentToAdd);
@@ -66,7 +66,7 @@ public class LibraryMetaTestTest {
         );
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] withLineReplacement")
     @MethodSource("withLineReplacementGenerator")
     void withLineReplacement(String oldCode, int start, int end, String replacement, String expectedResult) {
         LibraryMetaTest metaTest = (LibraryMetaTest) MetaTest.withLineReplacement("some meta test", start,end, replacement);
@@ -112,7 +112,7 @@ public class LibraryMetaTestTest {
         );
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] withStringReplacement")
     @MethodSource("withStringReplacementGenerator")
     void withStringReplacement(String oldCode, String old, String replacement, String expectedResult) {
         LibraryMetaTest metaTest = (LibraryMetaTest) MetaTest.withStringReplacement("some meta test", old, replacement);

--- a/andy/src/test/java/unit/utils/CodeSnippetUtilsTest.java
+++ b/andy/src/test/java/unit/utils/CodeSnippetUtilsTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class CodeSnippetUtilsTest {
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "[{index}] generateCodeSnippetSimple")
     @MethodSource("generator")
     void generateCodeSnippetSimple(List<String> lines, int lineNumber, String expected) {
         String actual = CodeSnippetUtils.generateCodeSnippet(lines, lineNumber);


### PR DESCRIPTION
Solves #207
I decided that simple naming scheme of index and name of parametrized test is good solution. It requires single line of code and if test fails it is easy to run it locally in IntelliJ and identify the problem.

Here are new outputs. I have changed the ones with long lines or containing line breaks.
<img width="452" alt="Screenshot 2023-07-08 at 20 21 24" src="https://github.com/SERG-Delft/andy/assets/18039619/acbca7be-7611-46cc-a053-d03e61663fd2">
<img width="464" alt="Screenshot 2023-07-08 at 20 21 39" src="https://github.com/SERG-Delft/andy/assets/18039619/1b816fe6-c0a0-43fb-947f-f4692615ac05">
<img width="781" alt="Screenshot 2023-07-08 at 20 23 14" src="https://github.com/SERG-Delft/andy/assets/18039619/2c0296fb-0c9e-4f71-9f3f-d27c885e33f8">
