### PR TITLE
Added Errorprone plugin

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/andy/src/test/java/unit/codechecker/engine/AndCheckTest.java
+++ b/andy/src/test/java/unit/codechecker/engine/AndCheckTest.java
@@ -52,6 +52,7 @@ public class AndCheckTest {
         verify(check2).runCheck(unit);
     }
 
+    @SuppressWarnings("SelfEquals")
     @Test
     void testSameObjectEquals() {
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,18 @@
                 <configuration>
                     <source>17</source>
                     <target>17</target>
+
+                    <compilerArgs>
+                        <arg>-XDcompilePolicy=simple</arg>
+                        <arg>-Xplugin:ErrorProne -Xep:DoubleBraceInitialization:WARN -Xep:EqualsHashCode:WARN</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.errorprone</groupId>
+                            <artifactId>error_prone_core</artifactId>
+                            <version>2.20.0</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
I added the Errorprone plugin and disabled the checks that broke the build. Those were:

1. DoubleBraceInitialization - forcing the usage of ImmutableHashMaps and ImmutableHashSets (in up to 10 places)
2. EqualsHashCode - forcing adding the hashCode() anywhere equals() was overridden (also up to 10 places). 

I refactored the code, but three tests failed (those were from AllAssignmentsTests, specifically from mocks-stubs-fakes). Since I did not see an immediate reason for that, I rolled back and just disabled these checks. However, I can try to search for that reason and enable the two checks if they are interesting for the project!