### PR TITLE
Add config setting for max discard ration to 2

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java
@@ -45,6 +45,7 @@ public class RunJUnitTestsStep implements ExecutionStep {
                     .configurationParameter("jqwik.reporting.usejunitplatform", "true")
                     .configurationParameter("jqwik.tries.default", "100")
                     .configurationParameter("jqwik.shrinking.default", "OFF")
+                    .configurationParameter("jqwik.maxdiscardratio.default", "2")
                     .configurationParameter("jqwik.database", FilesUtils.createTemporaryDirectory("jqwik").resolve("jqwik-db").toString())
                     .build();
             launcher.execute(request);

--- a/andy/src/test/java/integration/JUnitTestsTest.java
+++ b/andy/src/test/java/integration/JUnitTestsTest.java
@@ -180,12 +180,22 @@ public class JUnitTestsTest {
 
 
         @Test
+        void testBadAssumptionFilteringPropertyTest() {
+            Result result = run(Action.TESTS, "ArrayUtilsIndexOfLibrary", "ArrayUtilsIndexOfAssumptionJqwikError");
+
+            assertThat(result.getTests())
+                    .has(failingTest("testNoElementInWholeArray"));
+        }
+
+
+        @Test
         void testMultiplePropertyTestsFailing() {
             Result result = run(Action.TESTS, "ArrayUtilsIndexOfLibrary", "ArrayUtilsIndexOfMultipleJqwikErrors");
 
             assertThat(result.getTests())
                     .has(failingTest("testNoElementInWholeArray"))
-                    .has(failingTest("testValueInArrayUniqueElements"));
+                    .has(failingTest("testValueInArrayUniqueElements"))
+                    .has(failingTest("testNoElementInWholeArrayWithAssumption"));
         }
 
 

--- a/andy/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfAssumptionJqwikError.java
+++ b/andy/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfAssumptionJqwikError.java
@@ -1,0 +1,38 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import java.util.stream.*;
+import net.jqwik.api.*;
+import net.jqwik.api.arbitraries.*;
+import net.jqwik.api.constraints.*;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+
+class ArrayUtilsSimpleTests {
+
+    /** Use this method to convert a list of integers to an array */
+    private int[] convertListToArray(List<Integer> numbers) {
+        int[] array = numbers.stream().mapToInt(x -> x).toArray();
+        return array;
+    }
+
+    /** Test when the element specified is certainly not in the array.
+     *  The assumption we make is pretty unreasonable and this property
+     *  will be reported as 'exhausted' by jqwik.
+     */
+    @Property
+    void testNoElementInWholeArray(
+            @ForAll @Size(value=10) List<@IntRange(min = -2100000000, max = 2100000000) Integer> numbers,
+            @ForAll int valueToFind) {
+
+        Assume.that(valueToFind > 2100000000 || valueToFind < -2100000000);
+
+        int[] arr = convertListToArray(numbers);
+        assertEquals(-1, ArrayUtils.indexOf(arr, valueToFind, 0));
+    }
+
+}

--- a/andy/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfMultipleJqwikErrors.java
+++ b/andy/src/test/resources/grader/fixtures/Solution/ArrayUtilsIndexOfMultipleJqwikErrors.java
@@ -51,6 +51,18 @@ class ArrayUtilsMultipleTests {
         assertEquals(index, ArrayUtils.indexOf(arr, numbers.get(index), start));
     }
 
+    //test when the element specified is certainly not in the array using assumptions
+    @Property
+    void testNoElementInWholeArrayWithAssumption(
+            @ForAll @Size(value=10) List<@IntRange(min = -2100000000, max = 2100000000) Integer> numbers,
+            @ForAll int valueToFind) {
+
+        Assume.that(valueToFind > 2100000000 || valueToFind < -2100000000);
+
+        int[] arr = convertListToArray(numbers);
+        assertEquals(-1, ArrayUtils.indexOf(arr, valueToFind, 0));
+    }
+
     @Provide
     private Arbitrary<Integer> inexistentElement() {
         return Arbitraries.oneOf(


### PR DESCRIPTION
This PR adds another configuration step inside the jqwik config inside [RunJUnitTestsStep](https://github.com/SERG-Delft/andy/blob/main/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunJUnitTestsStep.java) that sets the maximum discard ratio to 2.

Additionally, this PR adds a new Solution fixture to check for discarding of a "correct" solution that uses Assume to filter out disproportionately big number of entries and changes the `testMultiplePropertyTestsFailing` method and relating fixture to test the scenario if a correct property with bad assumption filtering fails in the context of other failing property-based tests.

Closes #246 