### PR TITLE
exception handling Meta Tests

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/config/SecureExamRunConfiguration.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/config/SecureExamRunConfiguration.java
@@ -39,6 +39,10 @@ public class SecureExamRunConfiguration extends RunConfiguration {
         ));
     }
 
+    public List<MetaTest> metaTests() {
+        return Collections.emptyList();
+    }
+
     @Override
     public List<String> classesUnderTest() {
         return Collections.unmodifiableList(classesUnderTest);

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
@@ -30,44 +30,97 @@ public class LibraryMetaTest extends AbstractMetaTest {
     }
 
     @Override
-    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg) throws Exception {
-        /* Get the student solution, which we will run for each meta test */
-        String solutionFile = findSolution(dirCfg.getWorkingDir());
+    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg)throws Exception{
+        {/* Get the student solution, which we will run for each meta test */
+            String solutionFile = findSolution(dirCfg.getWorkingDir());
 
-        /* Get the original library content that we will keep changing according to the meta test */
-        File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
-        String originalLibraryContent = readFile(libraryFile);
+            /* Get the original library content that we will keep changing according to the meta test */
+            File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
+            String originalLibraryContent = readFile(libraryFile);
 
-        /*
-         * For each meta test, we basically perform a string replace in the
-         * original library code, recompile it, and run the tests.
-         * If there's a failing test, the meta test is killed.
-         *
-         * We reuse our execution framework to run the code with the meta test.
-         */
+            /*
+             * For each meta test, we basically perform a string replace in the
+             * original library code, recompile it, and run the tests.
+             * If there's a failing test, the meta test is killed.
+             *
+             * We reuse our execution framework to run the code with the meta test.
+             */
 
-        /* Copy the library and replace the library by the meta test */
-        File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
-        copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
-        String metaFileContent = generateMetaFileContent(originalLibraryContent);
-        createMetaTestFile(metaWorkingDir, metaFileContent);
+            /* Copy the library and replace the library by the meta test */
+            File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
+            copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
+            String metaFileContent = generateMetaFileContent(originalLibraryContent);
+            createMetaTestFile(metaWorkingDir, metaFileContent);
 
-        /* We then run the meta test, using our infrastructure */
-        Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
+            /* We then run the meta test, using our infrastructure */
+            Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
 
-        /* And check the result. If there's a failing test, the test suite is good! */
-        int testsRan = metaResult.getTests().getTestsRan();
-        int testsSucceeded = metaResult.getTests().getTestsSucceeded();
-        boolean passesTheMetaTest = testsSucceeded < testsRan;
+            /* And check the result. If there's a failing test, the test suite is good! */
+            int testsRan = metaResult.getTests().getTestsRan();
+            int testsSucceeded = metaResult.getTests().getTestsSucceeded();
+            boolean passesTheMetaTest = testsSucceeded < testsRan;
 
-        /* Clean up the directory */
-        deleteDirectory(metaWorkingDir);
+            /* Clean up the directory */
+            deleteDirectory(metaWorkingDir);
 
-        /* Set the classloader back to the one with the student's original code */
-        Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
+            /* Set the classloader back to the one with the student's original code */
+            Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
 
-        return passesTheMetaTest;
+            return passesTheMetaTest;
+        }
     }
+//  This was the execute method I updated, but this was causing a failing test in LibraryMetaTestsTest.
+//  So I decided to work on the RunMetaTestsStep class for error handling.
+//    @Override
+//    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg){
+//        try {/* Get the student solution, which we will run for each meta test */
+//            String solutionFile = findSolution(dirCfg.getWorkingDir());
+//
+//            /* Get the original library content that we will keep changing according to the meta test */
+//            File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
+//            String originalLibraryContent = readFile(libraryFile);
+//
+//            /*
+//             * For each meta test, we basically perform a string replace in the
+//             * original library code, recompile it, and run the tests.
+//             * If there's a failing test, the meta test is killed.
+//             *
+//             * We reuse our execution framework to run the code with the meta test.
+//             */
+//
+//            /* Copy the library and replace the library by the meta test */
+//            File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
+//            copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
+//            String metaFileContent = generateMetaFileContent(originalLibraryContent);
+//            createMetaTestFile(metaWorkingDir, metaFileContent);
+//
+//            /* We then run the meta test, using our infrastructure */
+//            Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
+//
+//            /* And check the result. If there's a failing test, the test suite is good! */
+//            int testsRan = metaResult.getTests().getTestsRan();
+//            int testsSucceeded = metaResult.getTests().getTestsSucceeded();
+//            boolean passesTheMetaTest = testsSucceeded < testsRan;
+//
+//            /* Clean up the directory */
+//            deleteDirectory(metaWorkingDir);
+//
+//            /* Set the classloader back to the one with the student's original code */
+//            Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
+//
+//            return passesTheMetaTest;
+//        } catch (Exception e){
+//            if(runCfg.mode().equals(Mode.EXAM)){
+//                System.out.println("Meta test compilation error occurred.");
+//            }
+//            else{
+//                System.err.println("Meta test compilation error occurred:");
+//                e.printStackTrace(System.err);
+//            }
+//            // if test fails, return false to keep it organized.
+//            return false;
+//        }
+//    }
 
     private String generateMetaFileContent(String originalLibraryContent) {
         String metaFileContent = evaluate(originalLibraryContent);

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
@@ -69,58 +69,6 @@ public class LibraryMetaTest extends AbstractMetaTest {
             return passesTheMetaTest;
         }
     }
-//  This was the execute method I updated, but this was causing a failing test in LibraryMetaTestsTest.
-//  So I decided to work on the RunMetaTestsStep class for error handling.
-//    @Override
-//    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg){
-//        try {/* Get the student solution, which we will run for each meta test */
-//            String solutionFile = findSolution(dirCfg.getWorkingDir());
-//
-//            /* Get the original library content that we will keep changing according to the meta test */
-//            File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
-//            String originalLibraryContent = readFile(libraryFile);
-//
-//            /*
-//             * For each meta test, we basically perform a string replace in the
-//             * original library code, recompile it, and run the tests.
-//             * If there's a failing test, the meta test is killed.
-//             *
-//             * We reuse our execution framework to run the code with the meta test.
-//             */
-//
-//            /* Copy the library and replace the library by the meta test */
-//            File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
-//            copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
-//            String metaFileContent = generateMetaFileContent(originalLibraryContent);
-//            createMetaTestFile(metaWorkingDir, metaFileContent);
-//
-//            /* We then run the meta test, using our infrastructure */
-//            Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
-//
-//            /* And check the result. If there's a failing test, the test suite is good! */
-//            int testsRan = metaResult.getTests().getTestsRan();
-//            int testsSucceeded = metaResult.getTests().getTestsSucceeded();
-//            boolean passesTheMetaTest = testsSucceeded < testsRan;
-//
-//            /* Clean up the directory */
-//            deleteDirectory(metaWorkingDir);
-//
-//            /* Set the classloader back to the one with the student's original code */
-//            Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
-//
-//            return passesTheMetaTest;
-//        } catch (Exception e){
-//            if(runCfg.mode().equals(Mode.EXAM)){
-//                System.out.println("Meta test compilation error occurred.");
-//            }
-//            else{
-//                System.err.println("Meta test compilation error occurred:");
-//                e.printStackTrace(System.err);
-//            }
-//            // if test fails, return false to keep it organized.
-//            return false;
-//        }
-//    }
 
     private String generateMetaFileContent(String originalLibraryContent) {
         String metaFileContent = evaluate(originalLibraryContent);

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/metatest/library/LibraryMetaTest.java
@@ -30,44 +30,43 @@ public class LibraryMetaTest extends AbstractMetaTest {
     }
 
     @Override
-    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg)throws Exception{
-        {/* Get the student solution, which we will run for each meta test */
-            String solutionFile = findSolution(dirCfg.getWorkingDir());
+    public boolean execute(Context ctx, DirectoryConfiguration dirCfg, RunConfiguration runCfg) throws Exception{
+        /* Get the student solution, which we will run for each meta test */
+        String solutionFile = findSolution(dirCfg.getWorkingDir());
 
-            /* Get the original library content that we will keep changing according to the meta test */
-            File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
-            String originalLibraryContent = readFile(libraryFile);
+        /* Get the original library content that we will keep changing according to the meta test */
+        File libraryFile = new File(findLibrary(dirCfg.getWorkingDir()));
+        String originalLibraryContent = readFile(libraryFile);
 
-            /*
-             * For each meta test, we basically perform a string replace in the
-             * original library code, recompile it, and run the tests.
-             * If there's a failing test, the meta test is killed.
-             *
-             * We reuse our execution framework to run the code with the meta test.
-             */
+        /*
+         * For each meta test, we basically perform a string replace in the
+         * original library code, recompile it, and run the tests.
+         * If there's a failing test, the meta test is killed.
+         *
+         * We reuse our execution framework to run the code with the meta test.
+         */
 
-            /* Copy the library and replace the library by the meta test */
-            File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
-            copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
-            String metaFileContent = generateMetaFileContent(originalLibraryContent);
-            createMetaTestFile(metaWorkingDir, metaFileContent);
+        /* Copy the library and replace the library by the meta test */
+        File metaWorkingDir = createTemporaryDirectory("metaWorkplace").toFile();
+        copyFile(solutionFile, metaWorkingDir.getAbsolutePath());
+        String metaFileContent = generateMetaFileContent(originalLibraryContent);
+        createMetaTestFile(metaWorkingDir, metaFileContent);
 
-            /* We then run the meta test, using our infrastructure */
-            Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
+        /* We then run the meta test, using our infrastructure */
+        Result metaResult = runMetaTest(ctx, dirCfg, metaWorkingDir);
 
-            /* And check the result. If there's a failing test, the test suite is good! */
-            int testsRan = metaResult.getTests().getTestsRan();
-            int testsSucceeded = metaResult.getTests().getTestsSucceeded();
-            boolean passesTheMetaTest = testsSucceeded < testsRan;
+        /* And check the result. If there's a failing test, the test suite is good! */
+        int testsRan = metaResult.getTests().getTestsRan();
+        int testsSucceeded = metaResult.getTests().getTestsSucceeded();
+        boolean passesTheMetaTest = testsSucceeded < testsRan;
 
-            /* Clean up the directory */
-            deleteDirectory(metaWorkingDir);
+        /* Clean up the directory */
+        deleteDirectory(metaWorkingDir);
 
-            /* Set the classloader back to the one with the student's original code */
-            Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
+        /* Set the classloader back to the one with the student's original code */
+        Thread.currentThread().setContextClassLoader(ctx.getClassloaderWithStudentsCode());
 
-            return passesTheMetaTest;
-        }
+        return passesTheMetaTest;
     }
 
     private String generateMetaFileContent(String originalLibraryContent) {

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
@@ -7,6 +7,7 @@ import nl.tudelft.cse1110.andy.execution.Context.Context;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.result.MetaTestResult;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,15 @@ public class RunMetaTestsStep implements ExecutionStep {
 
             result.logMetaTests(score, totalWeight, metaTestResults);
         } catch (Exception ex) {
-            result.genericFailure(this, ex);
+            if(runCfg.mode().equals(Mode.EXAM)){
+                System.out.println("Meta test compilation error occurred.");
+                result.genericFailure(this, ex);
+            }
+            else {
+                System.err.println("Meta test compilation error occurred:");
+                result.genericFailure(this, ex);
+                ex.printStackTrace(System.err);
+            }
         } finally {
             /* restore the class loader to the one before meta tests */
             Thread.currentThread().setContextClassLoader(currentClassLoader);

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/RunMetaTestsStep.java
@@ -45,8 +45,7 @@ public class RunMetaTestsStep implements ExecutionStep {
             result.logMetaTests(score, totalWeight, metaTestResults);
         } catch (Exception ex) {
             if(runCfg.mode().equals(Mode.EXAM)){
-                System.out.println("Meta test compilation error occurred.");
-                result.genericFailure(this, ex);
+                result.genericFailure(this, ex, "Compilation Error occured while running meta tests.");
             }
             else {
                 System.err.println("Meta test compilation error occurred:");

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
@@ -262,6 +262,17 @@ public class ResultBuilder {
         this.genericFailure(step.getClass().getSimpleName(), exceptionMessage(e));
     }
 
+    public void genericFailure(String step, String genericFailureExceptionMessage, String msg) {
+        this.genericFailureStepName = step;
+        this.genericFailureExceptionMessage = genericFailureExceptionMessage;
+        this.genericFailureMessage = msg;
+        this.buildGenericFailure();
+    }
+
+    public void genericFailure(ExecutionStep step, Throwable e, String msg) {
+        this.genericFailure(step.getClass().getSimpleName(), exceptionMessage(e), msg);
+    }
+
     /*
      * Build the final result
      */

--- a/andy/src/test/java/integration/LibraryMetaTestsTest.java
+++ b/andy/src/test/java/integration/LibraryMetaTestsTest.java
@@ -88,4 +88,15 @@ public class LibraryMetaTestsTest extends BaseMetaTestsTest {
                 .isEqualTo(RunMetaTestsStep.class.getSimpleName());
     }
 
+    @Test
+    void metaTestInternalFailureExamMode() {
+        Result result = run("NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass", "NumberUtilsAddConfigurationWithMetaTestInternalFailureExamMode");
+
+        assertThat(result.hasGenericFailure()).isTrue();
+        assertThat(result.getGenericFailure().getGenericFailureMessage())
+                .isPresent()
+                .get()
+                .isEqualTo("Compilation Error occured while running meta tests.");
+    }
+
 }

--- a/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
+++ b/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
@@ -173,42 +173,4 @@ public class LibraryMetaTestTest {
         assertThrows(RuntimeException.class,
                 () -> metaTest.evaluate("line 1\nline 2\nline 3\nline 4\nline 5"));
     }
-// I initially wrote this test because try-catch was inside LibraryMetaTest. Will remove it when decision is final.
-//    @Test
-//    void testExecuteWithCompilationErrorExamMode() throws Exception {
-//        // Create mock objects
-//        Context ctxMock = mock(Context.class);
-//        DirectoryConfiguration dirCfgMock = mock(DirectoryConfiguration.class);
-//        RunConfiguration runCfgMock = mock(RunConfiguration.class);
-//
-//        // Set up the behavior of the mock objects
-//        when(runCfgMock.mode()).thenReturn(Mode.EXAM);
-//        when(dirCfgMock.getWorkingDir()).thenThrow(new RuntimeException("Working directory exception."));
-//
-//        // Create the LibraryMetaTest object
-//        LibraryMetaTest metaTest = (LibraryMetaTest) MetaTest.withStringReplacement("some meta test",
-//                "line 5\nline 6",
-//                "extra line 1\nextra line 2");
-//
-//        // Create a stream to hold the output
-//        // if tests run in parallel, this could cause an issue as we capture logging and change system out settings.
-//        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
-//        PrintStream originalOut = System.out;
-//        System.setOut(new PrintStream(outContent));
-//
-//        // Test the execute method with the mocked objects
-//        boolean result = metaTest.execute(ctxMock, dirCfgMock, runCfgMock);
-//
-//        // Assertions
-//        assertFalse(result); // The test should fail due to the compilation error
-//
-//        // Verify that the proper methods were called on the mock objects
-//        verify(runCfgMock, times(1)).mode();
-//
-//        // Assert that the correct message was logged
-//        assertEquals("Meta test compilation error occurred.\n", outContent.toString());
-//
-//        // Restore System.out to its original
-//        System.setOut(originalOut);
-//    }
 }

--- a/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
+++ b/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
@@ -2,15 +2,26 @@ package unit.execution.metatest;
 
 import nl.tudelft.cse1110.andy.config.MetaTest;
 import nl.tudelft.cse1110.andy.execution.metatest.library.LibraryMetaTest;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
+import nl.tudelft.cse1110.andy.execution.Context.Context;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.mockito.Mockito;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
 
 public class LibraryMetaTestTest {
 
@@ -162,4 +173,42 @@ public class LibraryMetaTestTest {
         assertThrows(RuntimeException.class,
                 () -> metaTest.evaluate("line 1\nline 2\nline 3\nline 4\nline 5"));
     }
+// I initially wrote this test because try-catch was inside LibraryMetaTest. Will remove it when decision is final.
+//    @Test
+//    void testExecuteWithCompilationErrorExamMode() throws Exception {
+//        // Create mock objects
+//        Context ctxMock = mock(Context.class);
+//        DirectoryConfiguration dirCfgMock = mock(DirectoryConfiguration.class);
+//        RunConfiguration runCfgMock = mock(RunConfiguration.class);
+//
+//        // Set up the behavior of the mock objects
+//        when(runCfgMock.mode()).thenReturn(Mode.EXAM);
+//        when(dirCfgMock.getWorkingDir()).thenThrow(new RuntimeException("Working directory exception."));
+//
+//        // Create the LibraryMetaTest object
+//        LibraryMetaTest metaTest = (LibraryMetaTest) MetaTest.withStringReplacement("some meta test",
+//                "line 5\nline 6",
+//                "extra line 1\nextra line 2");
+//
+//        // Create a stream to hold the output
+//        // if tests run in parallel, this could cause an issue as we capture logging and change system out settings.
+//        ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+//        PrintStream originalOut = System.out;
+//        System.setOut(new PrintStream(outContent));
+//
+//        // Test the execute method with the mocked objects
+//        boolean result = metaTest.execute(ctxMock, dirCfgMock, runCfgMock);
+//
+//        // Assertions
+//        assertFalse(result); // The test should fail due to the compilation error
+//
+//        // Verify that the proper methods were called on the mock objects
+//        verify(runCfgMock, times(1)).mode();
+//
+//        // Assert that the correct message was logged
+//        assertEquals("Meta test compilation error occurred.\n", outContent.toString());
+//
+//        // Restore System.out to its original
+//        System.setOut(originalOut);
+//    }
 }

--- a/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
+++ b/andy/src/test/java/unit/execution/metatest/LibraryMetaTestTest.java
@@ -173,4 +173,5 @@ public class LibraryMetaTestTest {
         assertThrows(RuntimeException.class,
                 () -> metaTest.evaluate("line 1\nline 2\nline 3\nline 4\nline 5"));
     }
+
 }

--- a/andy/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithMetaTestInternalFailureExamMode.java
+++ b/andy/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithMetaTestInternalFailureExamMode.java
@@ -1,0 +1,84 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.config.SecureExamRunConfiguration;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends SecureExamRunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.1f);
+            put("mutation", 0.3f);
+            put("meta", 0.4f);
+            put("codechecks", 0.2f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.NumberUtils");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+            MetaTest.withStringReplacement(3, "AppliesMultipleCarriesWrongly",
+                """
+                int sum = leftDigit + rightDigit + carry;
+
+                result.addFirst(sum % 10);
+                carry = sum / 10;
+                """,
+                """
+                int sum;
+
+                if (leftDigit + rightDigit >= 10) {
+                    sum = leftDigit + rightDigit;
+                    carry = 1;
+                }
+                else {
+                    sum = leftDigit + rightDigit + carry;
+                    carry = 0;
+                }
+                result.addFirst(sum % 10);
+                """),
+            MetaTest.withLineReplacement("DoesNotApplyCarryAtAll", 47, 68,
+                """
+                for (int i = 0; i < Math.max(reversedLeft.size(), reversedRight.size()); i++) {
+
+                    int leftDigit = reversedLeft.size() > i ? reversedLeft.get(i) : 0;
+                    int rightDigit = reversedRight.size() > i ? reversedRight.get(i) : 0;
+
+                    if (leftDigit < 0 || leftDigit > 9 || rightDigit < 0 || rightDigit > 9)
+                        throw new IllegalArgumentException();
+
+                    int sum = leftDigit + rightDigit;
+
+                    result.addFirst(sum % 10);
+                }
+
+                // remove leading zeroes from the result
+                while (result.size() > 1 && result.get(0) == 0)
+                    result.remove(0);
+
+                if (result.isEmpty()) {
+                    result.addFirst(0);
+                }
+
+                return result;
+                """),
+            MetaTest.withStringReplacement("BadMetaTest",
+                "something that doesn't exist",
+                    ""),
+            MetaTest.withLineReplacement(2, "DoesNotCheckNumbersOutOfRange", 52, 53, "")
+        );
+    }
+}


### PR DESCRIPTION
I initially tried to work with compilation exceptions in the `LibraryMetaTest` but as there was already exception handling in `RunMetaTestsStep` I made the changes there.  I was not sure about how to alert the teacher if there was a compilation exception so I worked with console logging. Please Let me know if something else was intended with "alerting the teacher".

Another thing to note is that when I made the changes in `LibraryMetaTest` as errors would already be handled here, in the `RunMetaTestsStep` we would get failing tests that were initially meant to be there for error handling. So this was another reason for why I worked with `RunMetaTestsStep` folder instead. 

I did not delete the other changes, just in case, only commented them out. So when we reach a final decision on where to handle errors, I will delete those commented lines.  

Closes #227