### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,9 +115,6 @@ jobs:
           path: ~/.m2
           key: ${{ matrix.job.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ matrix.job.os }}-m2
-
-      - name: Compile and install everything
-        run: mvn install -pl andy -DskipTests
         
       - name: Run Weblab runner tests
         run: mvn test -pl weblab-runner -am -DexcludedGroups=selenium

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -120,4 +120,4 @@ jobs:
         run: mvn install -pl andy -DskipTests
         
       - name: Run Weblab runner tests
-        run: mvn test -pl weblab-runner -DexcludedGroups=selenium
+        run: mvn test -pl weblab-runner -am -DexcludedGroups=selenium


### PR DESCRIPTION
This PR fixes failing CI jobs due to unavailable dependencies. 

Added the `-am` option which makes Maven work smarter by building dependencies automatically. (We were already using this in the Docker image but not in the test step in the CI.) Removed an unnecessary installation step as andy is now built automatically.