### PR TITLE
Removed comments + added line highlight at position of keyword

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/result/ResultBuilder.java
@@ -78,9 +78,9 @@ public class ResultBuilder {
         this.compilation = CompilationResult.compilationFail(compilationErrors);
     }
 
-    public void compilationSecurityFail(String message) {
+    public void compilationSecurityFail(String message, Optional<Integer> lineNumber) {
         this.compilation = CompilationResult.compilationFail(List.of(
-                new CompilationErrorInfo("Solution.java", 1, message)
+                new CompilationErrorInfo("Solution.java", lineNumber.orElse(1), message) // Highlight first line if the line number does not exist
         ));
     }
 


### PR DESCRIPTION
The aim of this Pull Request is to improve the [SourceCodeSecurityCheckStep](https://github.com/SERG-Delft/andy/blob/main/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/SourceCodeSecurityCheckStep.java) class. 

- [ ] Change name of the class
- [ ] Remove comments when checking code
- [ ] When having an error highlight the corresponding line and not line 1. 
