### PR TITLE
Eliminated Boolean Arguments From getNumberOfPassedChecks and getTotalNumberOfChecks

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/grade/GradeValues.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/grade/GradeValues.java
@@ -89,7 +89,7 @@ public class GradeValues {
     public static GradeValues fromResults(CoverageResult coverageResults, CodeChecksResult codeCheckResults, MutationTestingResult mutationResults, MetaTestsResult metaTestResults, CodeChecksResult penaltyCodeCheckResults) {
         GradeValues grades = new GradeValues();
         grades.setBranchGrade(coverageResults.getCoveredBranches(), coverageResults.getTotalNumberOfBranches());
-        grades.setCheckGrade(codeCheckResults.getNumberOfPassedChecks(), codeCheckResults.getTotalNumberOfChecks());
+        grades.setCheckGrade(codeCheckResults.getWeightedNumberOfPassedChecks(), codeCheckResults.getTotalWeightedNumberOfChecks());
         grades.setMutationGrade(mutationResults.getKilledMutants(), mutationResults.getTotalNumberOfMutants());
         grades.setMetaGrade(metaTestResults.getPassedMetaTests(), metaTestResults.getTotalTests());
 

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/result/CodeChecksResult.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/result/CodeChecksResult.java
@@ -20,22 +20,22 @@ public class CodeChecksResult {
         return new CodeChecksResult(true, checkResults);
     }
 
-    public int getNumberOfPassedChecks() {
-        return getNumberOfPassedChecks(true);
+    public int getWeightedNumberOfPassedChecks() {
+        return checkResults.stream().mapToInt(
+                check -> check.passed() ? check.getWeight() : 0
+        ).sum();
     }
 
-    public int getNumberOfPassedChecks(boolean includeWeight) {
-        return checkResults.stream().mapToInt(check -> check.passed() ?
-                (includeWeight ? check.getWeight() : 1) :
-                0).sum();
+    public int getUnweightedNumberOfPassedChecks() {
+        return checkResults.stream().mapToInt(check -> check.passed() ? 1 : 0).sum();
     }
 
-    public int getTotalNumberOfChecks() {
-        return getTotalNumberOfChecks(true);
+    public int getTotalWeightedNumberOfChecks() {
+        return checkResults.stream().mapToInt(CodeCheckResult::getWeight).sum();
     }
 
-    public int getTotalNumberOfChecks(boolean includeWeight) {
-        return checkResults.stream().mapToInt(c -> includeWeight ? c.getWeight() : 1).sum();
+    public int getTotalUnweightedNumberOfChecks() {
+        return checkResults.size();
     }
 
     public List<CodeCheckResult> getCheckResults() {

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/writer/standard/StandardResultWriter.java
@@ -173,7 +173,7 @@ public class StandardResultWriter implements ResultWriter {
         if(result.getCompilation().successful()) {
             printGradeCalculationDetails("Branch coverage", result.getCoverage().getCoveredBranches(), result.getCoverage().getTotalNumberOfBranches(), result.getWeights().getBranchCoverageWeight());
             printGradeCalculationDetails("Mutation coverage", result.getMutationTesting().getKilledMutants(), result.getMutationTesting().getTotalNumberOfMutants(), result.getWeights().getMutationCoverageWeight());
-            printGradeCalculationDetails("Code checks", result.getCodeChecks().getNumberOfPassedChecks(), result.getCodeChecks().getTotalNumberOfChecks(), result.getWeights().getCodeChecksWeight());
+            printGradeCalculationDetails("Code checks", result.getCodeChecks().getWeightedNumberOfPassedChecks(), result.getCodeChecks().getTotalWeightedNumberOfChecks(), result.getWeights().getCodeChecksWeight());
             printGradeCalculationDetails("Meta tests", result.getMetaTests().getPassedMetaTests(), result.getMetaTests().getTotalTests(), result.getWeights().getMetaTestsWeight());
         }
 
@@ -309,8 +309,8 @@ public class StandardResultWriter implements ResultWriter {
     }
 
     private void printCodeCheckOutput(CodeChecksResult codeChecks, CodeChecksResult penaltyCodeChecks, boolean allHints) {
-        l(String.format("%d/%d passed", codeChecks.getNumberOfPassedChecks() + penaltyCodeChecks.getNumberOfPassedChecks(false),
-                codeChecks.getTotalNumberOfChecks() + penaltyCodeChecks.getTotalNumberOfChecks(false)));
+        l(String.format("%d/%d passed", codeChecks.getWeightedNumberOfPassedChecks() + penaltyCodeChecks.getUnweightedNumberOfPassedChecks(),
+                codeChecks.getTotalWeightedNumberOfChecks() + penaltyCodeChecks.getTotalUnweightedNumberOfChecks()));
 
         if(allHints) {
             for (CodeCheckResult result : codeChecks.getCheckResults()) {

--- a/andy/src/test/java/integration/CodeChecksTest.java
+++ b/andy/src/test/java/integration/CodeChecksTest.java
@@ -68,8 +68,8 @@ public class CodeChecksTest extends IntegrationTestBase {
         return new Condition<>() {
             @Override
             public boolean matches(Result value) {
-                boolean testsPassed = value.getCodeChecks().getNumberOfPassedChecks() == passed;
-                boolean totalChecks = value.getCodeChecks().getTotalNumberOfChecks() == total;
+                boolean testsPassed = value.getCodeChecks().getWeightedNumberOfPassedChecks() == passed;
+                boolean totalChecks = value.getCodeChecks().getTotalWeightedNumberOfChecks() == total;
 
                 return testsPassed && totalChecks;
             }

--- a/andy/src/test/java/integration/JacocoTest.java
+++ b/andy/src/test/java/integration/JacocoTest.java
@@ -116,7 +116,7 @@ public class JacocoTest extends IntegrationTestBase {
 
         // verify that the grade is only 0 because there is no coverage
         assertThat(result.getCodeChecks().wasExecuted()).isTrue();
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(1);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(1);
         assertThat(result.getWeights().getCodeChecksWeight()).isNotZero();
     }
 

--- a/andy/src/test/java/integration/ModesAndActionsTest.java
+++ b/andy/src/test/java/integration/ModesAndActionsTest.java
@@ -21,10 +21,10 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredLines()).isEqualTo(11);
         assertThat(result.getMutationTesting().getKilledMutants()).isEqualTo(8);
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(9);
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(3);
-        assertThat(result.getCodeChecks().getTotalNumberOfChecks()).isEqualTo(3);
-        assertThat(result.getPenaltyCodeChecks().getNumberOfPassedChecks()).isEqualTo(200);
-        assertThat(result.getPenaltyCodeChecks().getTotalNumberOfChecks()).isEqualTo(200);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(3);
+        assertThat(result.getPenaltyCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(200);
+        assertThat(result.getPenaltyCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(200);
         assertThat(result)
                 .has(codeCheck("Trip Repository should be mocked", true, 1))
                 .has(codeCheck("Trip should not be mocked", true, 1))
@@ -43,8 +43,8 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredLines()).isEqualTo(11);
         assertThat(result.getMutationTesting().getKilledMutants()).isEqualTo(8);
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(9);
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(3);
-        assertThat(result.getCodeChecks().getTotalNumberOfChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(3);
         assertThat(result.getPenaltyCodeChecks().hasChecks()).isFalse();
         assertThat(result.getPenaltyCodeChecks().wasExecuted()).isTrue();
         assertThat(result.getMetaTests().getTotalTests()).isEqualTo(4);
@@ -61,14 +61,14 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredLines()).isEqualTo(11);
         assertThat(result.getMutationTesting().getKilledMutants()).isEqualTo(8);
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(9);
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(3);
-        assertThat(result.getCodeChecks().getTotalNumberOfChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(3);
         assertThat(result.getPenaltyCodeChecks().hasChecks()).isTrue();
         assertThat(result.getPenaltyCodeChecks().wasExecuted()).isTrue();
         assertThat(result.getMetaTests().getTotalTests()).isEqualTo(4);
         assertThat(result.getMetaTests().getPassedMetaTests()).isEqualTo(3);
-        assertThat(result.getPenaltyCodeChecks().getNumberOfPassedChecks()).isEqualTo(10);
-        assertThat(result.getPenaltyCodeChecks().getTotalNumberOfChecks()).isEqualTo(10 + 5 + 3);
+        assertThat(result.getPenaltyCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(10);
+        assertThat(result.getPenaltyCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(10 + 5 + 3);
         assertThat(result)
                 .has(penaltyCodeCheck("Trip Repository should not be mocked penalty", false, 5))
                 .has(penaltyCodeCheck("Trip should be mocked penalty", false, 3))
@@ -84,14 +84,14 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredLines()).isEqualTo(11);
         assertThat(result.getMutationTesting().getKilledMutants()).isEqualTo(8);
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(9);
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(3);
-        assertThat(result.getCodeChecks().getTotalNumberOfChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(3);
         assertThat(result.getPenaltyCodeChecks().hasChecks()).isTrue();
         assertThat(result.getPenaltyCodeChecks().wasExecuted()).isTrue();
         assertThat(result.getMetaTests().getTotalTests()).isEqualTo(4);
         assertThat(result.getMetaTests().getPassedMetaTests()).isEqualTo(3);
-        assertThat(result.getPenaltyCodeChecks().getNumberOfPassedChecks(false)).isEqualTo(1);
-        assertThat(result.getPenaltyCodeChecks().getTotalNumberOfChecks(false)).isEqualTo(3);
+        assertThat(result.getPenaltyCodeChecks().getUnweightedNumberOfPassedChecks()).isEqualTo(1);
+        assertThat(result.getPenaltyCodeChecks().getTotalUnweightedNumberOfChecks()).isEqualTo(3);
         assertThat(result)
                 .has(penaltyCodeCheck("Trip Repository should not be mocked penalty", false, 100))
                 .has(penaltyCodeCheck("Trip should be mocked penalty", false, 30))
@@ -145,10 +145,10 @@ public class ModesAndActionsTest extends IntegrationTestBase {
         assertThat(result.getCoverage().getCoveredLines()).isEqualTo(11);
         assertThat(result.getMutationTesting().getKilledMutants()).isEqualTo(8);
         assertThat(result.getMutationTesting().getTotalNumberOfMutants()).isEqualTo(9);
-        assertThat(result.getCodeChecks().getNumberOfPassedChecks()).isEqualTo(3);
-        assertThat(result.getCodeChecks().getTotalNumberOfChecks()).isEqualTo(3);
-        assertThat(result.getPenaltyCodeChecks().getNumberOfPassedChecks()).isEqualTo(100);
-        assertThat(result.getPenaltyCodeChecks().getTotalNumberOfChecks()).isEqualTo(105);
+        assertThat(result.getCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(3);
+        assertThat(result.getCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(3);
+        assertThat(result.getPenaltyCodeChecks().getWeightedNumberOfPassedChecks()).isEqualTo(100);
+        assertThat(result.getPenaltyCodeChecks().getTotalWeightedNumberOfChecks()).isEqualTo(105);
         assertThat(result)
                 .has(codeCheck("Trip Repository should be mocked", true, 1))
                 .has(codeCheck("Trip should not be mocked", true, 1))

--- a/weblab-runner/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
+++ b/weblab-runner/src/main/java/nl/tudelft/cse1110/andy/writer/weblab/WebLabResultWriter.java
@@ -96,7 +96,7 @@ public class WebLabResultWriter extends StandardResultWriter {
 
         appendMetaScore(doc, metaElement, "Branch coverage", result.getCoverage().getCoveredBranches());
         appendMetaScore(doc, metaElement, "Mutation coverage", result.getMutationTesting().getKilledMutants());
-        appendMetaScore(doc, metaElement, "Code checks", result.getCodeChecks().getNumberOfPassedChecks());
+        appendMetaScore(doc, metaElement, "Code checks", result.getCodeChecks().getWeightedNumberOfPassedChecks());
         appendMetaScore(doc, metaElement, "Meta tests", result.getMetaTests().getPassedMetaTests());
 
         result.getCodeChecks().getCheckResults().forEach(check -> appendMetaScore(doc, metaElement, check.getDescription(), check.passed() ? 1 : 0));


### PR DESCRIPTION
Closes #219.

Refactored a few methods in the `CodeChecksResult` class:
- `getNumberOfPassedChecks()` is now `getWeightedNumberOfPassedChecks()`;
- removed `getNumberOfPassedChecks(boolean includeWeight)`;
- added `getUnweightedNumberOfPassedChecks()`;
- `getTotalNumberOfChecks()` is now `getTotalWeightedNumberOfChecks()`;
- removed `getTotalNumberOfChecks(boolean includeWeight)`;
- added `getTotalUnweightedNumberOfChecks()`.

Fixed the method calls, of course, and the behaviour is exactly the same. I wasn't sure if I should refactor `getTotalNumberOfChecks`, in addition to `getNumberOfPassedChecks`, but I did anyway, since it seemed sensible.