### PR TITLE
Configure Mockito to disable the Objenesis class cache

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/ReplaceClassloaderStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/ReplaceClassloaderStep.java
@@ -4,16 +4,13 @@ import nl.tudelft.cse1110.andy.execution.Context.Context;
 import nl.tudelft.cse1110.andy.config.DirectoryConfiguration;
 import nl.tudelft.cse1110.andy.execution.ExecutionStep;
 import nl.tudelft.cse1110.andy.result.ResultBuilder;
-import org.objenesis.ObjenesisStd;
 
-import java.lang.reflect.Field;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * This step replaces the classloader with one that sees the folder
@@ -29,7 +26,6 @@ public class ReplaceClassloaderStep implements ExecutionStep {
             String pathToAddToClassloader = dirCfg.getWorkingDir();
             replaceClassloader(ctx, pathToAddToClassloader);
             ctx.setClassloaderWithStudentsCode(Thread.currentThread().getContextClassLoader());
-            clearMockitoObjenesisInstantiatorCache();
         } catch (Exception e) {
             result.genericFailure(this, e);
         }
@@ -42,27 +38,6 @@ public class ReplaceClassloaderStep implements ExecutionStep {
         ClassLoader customClassLoader = URLClassLoader.newInstance(urls, currentClassloader);
 
         Thread.currentThread().setContextClassLoader(customClassLoader);
-    }
-
-    private void clearMockitoObjenesisInstantiatorCache() throws ReflectiveOperationException {
-            Class<?> defaultInstantiatorProviderClass = Class.forName(
-                    "org.mockito.internal.creation.instance.DefaultInstantiatorProvider");
-            Field objenesisInstantiatorField = defaultInstantiatorProviderClass.getDeclaredField("INSTANCE");
-            objenesisInstantiatorField.setAccessible(true);
-
-            // org.mockito.internal.creation.instance.ObjenesisInstantiator
-            Object objenesisInstantiator = objenesisInstantiatorField.get(null);
-            Field objenesisStdField = objenesisInstantiator.getClass().getDeclaredField("objenesis");
-            objenesisStdField.setAccessible(true);
-
-            // org.objenesis.ObjenesisStd extends ObjenesisBase
-            ObjenesisStd objenesisStd = (ObjenesisStd) objenesisStdField.get(objenesisInstantiator);
-            Field objenesisBaseCacheField = objenesisStd.getClass().getSuperclass().getDeclaredField("cache");
-            objenesisBaseCacheField.setAccessible(true);
-
-            // clear instantiator cache
-            ConcurrentHashMap<?, ?> cache = (ConcurrentHashMap<?, ?>) objenesisBaseCacheField.get(objenesisStd);
-            cache.clear();
     }
 
     private URL toURL(Path path) {

--- a/andy/src/main/java/org/mockito/configuration/MockitoConfiguration.java
+++ b/andy/src/main/java/org/mockito/configuration/MockitoConfiguration.java
@@ -1,0 +1,12 @@
+package org.mockito.configuration;
+
+// The presence of this class configures Mockito to disable the Objenesis cache.
+// Caching causes problems when we dynamically replace classes in meta tests.
+
+@SuppressWarnings("unused")
+public class MockitoConfiguration extends DefaultMockitoConfiguration {
+    @Override
+    public boolean enableClassCache() {
+        return false;
+    }
+}

--- a/andy/src/test/java/integration/LibraryMetaTestsTest.java
+++ b/andy/src/test/java/integration/LibraryMetaTestsTest.java
@@ -130,4 +130,12 @@ public class LibraryMetaTestsTest extends BaseMetaTestsTest {
                 .has(failedMetaTest("DoesNotApplyLastCarry"));
     }
 
+    @Test
+    void metaTestsWithMockitoAndCustomException() {
+        Result result = run("MockingAssignmentWithCustomExceptionLibrary", "MockingAssignmentWithCustomExceptionWrongWithoutAssertions", "MockingAssignmentWithCustomExceptionConfiguration");
+
+        assertThat(result.getMetaTests().getPassedMetaTests()).isEqualTo(0);
+        assertThat(result.getMetaTests().getTotalTests()).isEqualTo(1);
+    }
+
 }

--- a/andy/src/test/java/integration/LibraryMetaTestsTest.java
+++ b/andy/src/test/java/integration/LibraryMetaTestsTest.java
@@ -135,7 +135,7 @@ public class LibraryMetaTestsTest extends BaseMetaTestsTest {
         Result result = run("MockingAssignmentWithCustomExceptionLibrary", "MockingAssignmentWithCustomExceptionWrongWithoutAssertions", "MockingAssignmentWithCustomExceptionConfiguration");
 
         assertThat(result.getMetaTests().getPassedMetaTests()).isEqualTo(0);
-        assertThat(result.getMetaTests().getTotalTests()).isEqualTo(1);
+        assertThat(result.getMetaTests().getTotalTests()).isEqualTo(2);
     }
 
 }

--- a/andy/src/test/resources/grader/fixtures/Config/MockingAssignmentWithCustomExceptionConfiguration.java
+++ b/andy/src/test/resources/grader/fixtures/Config/MockingAssignmentWithCustomExceptionConfiguration.java
@@ -42,7 +42,10 @@ public class Configuration extends RunConfiguration {
         return List.of(
                 MetaTest.withStringReplacement("my meta test",
                         "a == 10",
-                        "a == 15")
+                        "a == 15"),
+                MetaTest.withStringReplacement("another meta test",
+                        "a == 10",
+                        "a == 20")
         );
     }
 }

--- a/andy/src/test/resources/grader/fixtures/Config/MockingAssignmentWithCustomExceptionConfiguration.java
+++ b/andy/src/test/resources/grader/fixtures/Config/MockingAssignmentWithCustomExceptionConfiguration.java
@@ -1,0 +1,48 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.codechecker.checks.Comparison;
+import nl.tudelft.cse1110.andy.codechecker.checks.MethodCalledAnywhere;
+import nl.tudelft.cse1110.andy.codechecker.checks.MockClass;
+import nl.tudelft.cse1110.andy.codechecker.checks.MockitoVerify;
+import nl.tudelft.cse1110.andy.codechecker.engine.AndCheck;
+import nl.tudelft.cse1110.andy.codechecker.engine.CheckScript;
+import nl.tudelft.cse1110.andy.codechecker.engine.SingleCheck;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.execution.mode.Mode;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Mode mode() {
+        return Mode.GRADING;
+    }
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.0f);
+            put("mutation", 0.0f);
+            put("meta", 1.0f);
+            put("codechecks", 0.0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.MyService");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+                MetaTest.withStringReplacement("my meta test",
+                        "a == 10",
+                        "a == 15")
+        );
+    }
+}

--- a/andy/src/test/resources/grader/fixtures/Library/MockingAssignmentWithCustomExceptionLibrary.java
+++ b/andy/src/test/resources/grader/fixtures/Library/MockingAssignmentWithCustomExceptionLibrary.java
@@ -1,0 +1,29 @@
+package delft;
+
+class MyService {
+    private final AnotherService anotherService;
+
+    public MyService(AnotherService anotherService) {
+        this.anotherService = anotherService;
+    }
+
+    public boolean myMethod(int a) {
+        if (a == 10) {
+            return false;
+        }
+
+        try {
+            return anotherService.anotherMethod();
+        } catch (MyException e) {
+            return false;
+        }
+    }
+
+}
+
+interface AnotherService {
+    boolean anotherMethod() throws MyException;
+}
+
+class MyException extends Exception {
+}

--- a/andy/src/test/resources/grader/fixtures/Solution/MockingAssignmentWithCustomExceptionWrongWithoutAssertions.java
+++ b/andy/src/test/resources/grader/fixtures/Solution/MockingAssignmentWithCustomExceptionWrongWithoutAssertions.java
@@ -1,0 +1,29 @@
+package delft;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import java.time.*;
+import java.util.stream.*;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
+import org.mockito.*;
+
+class MyServiceTest {
+
+    @Test
+    void test() throws MyException {
+        var anotherService = Mockito.mock(AnotherService.class);
+        var myService = new MyService(anotherService);
+
+        when(anotherService.anotherMethod()).thenThrow(MyException.class);
+
+        boolean result = myService.myMethod(1);
+    }
+
+}


### PR DESCRIPTION
In meta tests, we dynamically reload classes. This causes casting issues when Objenesis caches an instantiator for a class that is later replaced.