### PR TITLE
Fix Mockito do-syntax

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MockitoWhen.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MockitoWhen.java
@@ -47,16 +47,12 @@ public class MockitoWhen extends Check {
          * If the method call just after when() matches the one we are expecting, bingo!
          */
         if(inWhenMode) {
-            if(methodToSetUp.equals(methodName) || methodToSetUp.equals(previousMethodName)) {
+            if(methodToSetUp.equals(methodName) ||
+                    methodToSetUp.equals(previousMethodName) && allowedDoInvocations.contains(methodName)) {
                 numberOfCallsToWhen++;
-                inWhenMode = false;
-                previousMethodName = "";
-            } else if(notInDoWhenOrNoMatch(methodName)){
-                inWhenMode = false;
-                previousMethodName = "";
-            } else {
-                previousMethodName = methodName;
             }
+            inWhenMode = false;
+            previousMethodName = "";
         } else {
             /**
              * We wait for a call to when().
@@ -70,12 +66,7 @@ public class MockitoWhen extends Check {
         }
         return super.visit(mi);
     }
-    private boolean notInDoWhenOrNoMatch(String methodName){
-        return !methodName.equals("when")
-                &&
-            (allowedDoInvocations.contains(previousMethodName)
-                || !allowedDoInvocations.contains(methodName));
-    }
+
     @Override
     public boolean result() {
         return comparison.compare(numberOfCallsToWhen, expectedNumberOfOccurrences);

--- a/andy/src/test/resources/codechecker/fixtures/MockitoWhenCalls.java
+++ b/andy/src/test/resources/codechecker/fixtures/MockitoWhenCalls.java
@@ -36,7 +36,7 @@ public class MockitoWhenCalls {
     void t3(){
         List<String> mockedList = mock(List.class);
         Mockito.doThrow(IllegalArgumentException.class).when(mockedList).toString();
-        doNothing().when(mockedList.size());
+        doNothing().when(mockedList).size();
         doReturn("2").when(mockedList).get(any(Integer.class));
 
         verify(mockedList, times(2)).toString();
@@ -46,15 +46,29 @@ public class MockitoWhenCalls {
     @Test
     void t4(){
         List<String> mockedList = mock(List.class);
-        Mockito.doNothing().when(mockedList.size());
-        doReturn("2").when(mockedList.get(any(Integer.class)));
-        doReturn("3").when(mockedList.remove(any(Integer.class)));
+        Mockito.doNothing().when(mockedList).size();
+        doReturn("2").when(mockedList).get(any(Integer.class));
+        doReturn("3").when(mockedList).remove(any(Integer.class));
 
         verify(mockedList, times(1)).remove(1);
         verify(mockedList, times(1)).remove(2);
         verify(mockedList, times(1)).remove(3);
         verify(mockedList, times(1)).get(4);
         verify(mockedList, times(1)).get(5);
+    }
+
+    @Test
+    void t5(){
+        List<String> mockedList = mock(List.class);
+        Mockito.doReturn(3).when(mockedList).size();
+        mockedList.get(3);
+    }
+
+    @Test
+    void t6(){
+        List<String> mockedList = mock(List.class);
+        Mockito.doReturn(3).when(mockedList.get(3));
+        mockedList.get(3);
     }
 
 }


### PR DESCRIPTION
The current implementation was checking for Mockito do-syntax in the form `doReturn(something).when(repository.find(1))`, which is invalid syntax. It should instead be `doReturn(something).when(repository).find(1)`.