### PR TITLE
Add a constructor to MethodCalledInTestMethod to support matching a specific expression

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         job:
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-15
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
@@ -66,7 +66,7 @@ jobs:
       matrix:
         job:
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-15
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
@@ -98,7 +98,7 @@ jobs:
       matrix:
         job:
           - os: ubuntu-22.04
-          - os: macos-12
+          - os: macos-15
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   checkstyle:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
     steps:
@@ -33,8 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - os: ubuntu-22.04
-          - os: macos-15
+          - os: ubuntu-latest
+          - os: macos-latest
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
@@ -65,8 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - os: ubuntu-22.04
-          - os: macos-15
+          - os: ubuntu-latest
+          - os: macos-latest
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
@@ -97,8 +97,8 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - os: ubuntu-22.04
-          - os: macos-15
+          - os: ubuntu-latest
+          - os: macos-latest
           - os: windows-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
 
@@ -118,6 +118,6 @@ jobs:
           path: ~/.m2
           key: ${{ matrix.job.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ matrix.job.os }}-m2
-        
+
       - name: Run Weblab runner tests
         run: mvn test -pl weblab-runner -am -DexcludedGroups=selenium

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MethodCalledAnywhere.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MethodCalledAnywhere.java
@@ -1,33 +1,16 @@
 package nl.tudelft.cse1110.andy.codechecker.checks;
 
-import org.eclipse.jdt.core.dom.MethodInvocation;
-
-public class MethodCalledAnywhere extends Check {
-    private final String methodToBeCalled;
-    private boolean methodWasCalled = false;
-
+public class MethodCalledAnywhere extends MethodCalledInTestMethod {
     public MethodCalledAnywhere(String methodToBeCalled) {
-        this.methodToBeCalled = methodToBeCalled;
+        super(methodToBeCalled);
+    }
+
+    public MethodCalledAnywhere(String expression, String methodToBeCalled) {
+        super(expression, methodToBeCalled);
     }
 
     @Override
-    public boolean visit(MethodInvocation mi) {
-
-        String methodName = mi.getName().toString();
-
-        if (methodToBeCalled.equals(methodName))
-            methodWasCalled = true;
-
-        return super.visit(mi);
-    }
-
-
-    @Override
-    public boolean result() {
-        return methodWasCalled;
-    }
-
-    public String toString() {
-        return methodToBeCalled + " method is called";
+    protected boolean isInTheAnnotatedMethod(){
+        return true;
     }
 }

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MethodCalledInTestMethod.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/MethodCalledInTestMethod.java
@@ -14,26 +14,42 @@ import org.eclipse.jdt.core.dom.MethodInvocation;
  */
 public class MethodCalledInTestMethod extends WithinTestMethod {
 
+    private final String expression;
     private final String methodToBeCalled;
     private boolean methodWasCalled = false;
 
     public MethodCalledInTestMethod(String methodToBeCalled) {
+        this(null, methodToBeCalled);
+    }
+
+    /**
+     * This constructor allows you to find nodes such as `Arbitraries.of(1, 2)`:
+     * the part before the dot (`Arbitraries`) is the expression, the part after it (`of`) is the methodToBeCalled.
+     * Note that we do not check the type of the expression, only the literal syntax.
+     * (It should theoretically be possible to find the type binding for the expression, but JDT
+     * does not seem to allow finding bindings for nested expressions like in `user.name.toString()`,
+     * so adding this would have limited value.)
+     */
+    public MethodCalledInTestMethod(String expression, String methodToBeCalled) {
+        this.expression = expression;
         this.methodToBeCalled = methodToBeCalled;
     }
 
     @Override
     public boolean visit(MethodInvocation mi) {
-
         if(isInTheAnnotatedMethod()) {
             String methodName = mi.getName().toString();
 
-            if (methodToBeCalled.equals(methodName))
-                methodWasCalled = true;
+            if (expression == null
+                    || mi.getExpression() == null
+                    || expression.equals(mi.getExpression().toString())) {
+                if (methodToBeCalled.equals(methodName))
+                    methodWasCalled = true;
+            }
         }
 
         return super.visit(mi);
     }
-
 
     @Override
     public boolean result() {

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/TestMethodsHaveAssertions.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/TestMethodsHaveAssertions.java
@@ -68,11 +68,11 @@ public class TestMethodsHaveAssertions extends WithinTestMethod {
 
     @Override
     public void endVisit(MethodDeclaration md) {
-        /**
-         * if we are in a test method, and at the end of the method,
-         * we did not find any assertions, then, we have a problem.
+        /*
+         * if we are in a test method, and at the end of the method
+         * we did not find any assertions, then we have a problem.
          */
-        if(isInTheAnnotatedMethod() && !currentMethodContainsAssertion) {
+        if(isInTheAnnotatedMethod() && !currentMethodContainsAssertion && !inAnonymousClass) {
             this.containsATestWithoutAssertion = true;
         }
 

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
@@ -7,7 +7,7 @@ import java.util.Set;
 public abstract class WithinAnnotatedMethod extends Check {
 
     private boolean annotationFound = false;
-    private boolean inAnonymousClass = false;
+    protected boolean inAnonymousClass = false;
 
     protected abstract Set<String> annotations();
 

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
@@ -7,6 +7,7 @@ import java.util.Set;
 public abstract class WithinAnnotatedMethod extends Check {
 
     private boolean annotationFound = false;
+    private boolean inAnonymousClass = false;
 
     protected abstract Set<String> annotations();
 
@@ -30,6 +31,11 @@ public abstract class WithinAnnotatedMethod extends Check {
 
 
     private void checkIfThisIsATestAnnotation(Name name) {
+        if (inAnonymousClass) {
+            // Ignore all annotations within anonymous classes
+            return;
+        }
+
         if (annotations().contains(name.getFullyQualifiedName()))
             annotationFound = true;
     }
@@ -40,17 +46,23 @@ public abstract class WithinAnnotatedMethod extends Check {
 
     @Override
     public void endVisit(MethodDeclaration md) {
-        /**
-         * whenever we finish visiting a method, we remove the
-         * flag.
+        /*
+         * whenever we finish visiting a method, we remove the flag,
+         * unless we're in an anonymous class (because then we haven't reached the end of the annotated method)
          */
-        annotationFound = false;
+        if (!inAnonymousClass) {
+            annotationFound = false;
+        }
     }
-
 
     @Override
     public boolean visit(AnonymousClassDeclaration classDeclaration) {
-        // we fully ignore anonymous classes
-        return false;
+        inAnonymousClass = true;
+        return super.visit(classDeclaration);
+    }
+
+    @Override
+    public void endVisit(AnonymousClassDeclaration classDeclaration) {
+        inAnonymousClass = false;
     }
 }

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/checks/WithinAnnotatedMethod.java
@@ -6,8 +6,8 @@ import java.util.Set;
 
 public abstract class WithinAnnotatedMethod extends Check {
 
-    private boolean annotationFound = false;
     protected boolean inAnonymousClass = false;
+    private boolean annotationFound = false;
 
     protected abstract Set<String> annotations();
 

--- a/andy/src/test/java/unit/codechecker/checks/MethodCalledAnywhereTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MethodCalledAnywhereTest.java
@@ -37,4 +37,23 @@ public class MethodCalledAnywhereTest extends ChecksBaseTest {
         run("StackOverflowTestWithAnonymousClass.java", check);
         assertThat(check.result()).isTrue();
     }
+
+    @Test
+    void shouldMatchExpression() { // checks whether the alternate constructor works
+        Check check = new MethodCalledAnywhere("Utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isTrue();
+
+        check = new MethodCalledAnywhere("MethodCalled.Utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isTrue();
+
+        check = new MethodCalledAnywhere("utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isFalse();
+
+        check = new MethodCalledAnywhere("repo", "retrieve");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isTrue();
+    }
 }

--- a/andy/src/test/java/unit/codechecker/checks/MethodCalledAnywhereTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MethodCalledAnywhereTest.java
@@ -2,7 +2,6 @@ package unit.codechecker.checks;
 
 import nl.tudelft.cse1110.andy.codechecker.checks.Check;
 import nl.tudelft.cse1110.andy.codechecker.checks.MethodCalledAnywhere;
-import nl.tudelft.cse1110.andy.codechecker.checks.MethodCalledInTestMethod;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -26,10 +25,16 @@ public class MethodCalledAnywhereTest extends ChecksBaseTest {
     }
 
     @Test
-    void shouldIgnoreAnonymousClasses() { // was breaking in midterm 2021
-        Check check = new MethodCalledInTestMethod("getPoints");
+    void shouldNotBreakWhenAnonymousClassesAreUsed() { // was breaking in midterm 2021
+        Check check = new MethodCalledAnywhere("getPoints");
         run("StackOverflowTestWithAnonymousClass.java", check);
         assertThat(check.result()).isTrue();
     }
 
+    @Test
+    void shouldCheckForMethodCallsInsideAnonymousClasses() {
+        Check check = new MethodCalledAnywhere("disableGravity");
+        run("StackOverflowTestWithAnonymousClass.java", check);
+        assertThat(check.result()).isTrue();
+    }
 }

--- a/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
@@ -57,6 +57,10 @@ public class MethodCalledInTestMethodTest extends ChecksBaseTest {
         check = new MethodCalledInTestMethod("utils", "fromString");
         run("MethodCalled.java", check);
         assertThat(check.result()).isFalse();
+
+        check = new MethodCalledInTestMethod("repo", "retrieve");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isFalse();
     }
 
 }

--- a/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
@@ -30,4 +30,19 @@ public class MethodCalledInTestMethodTest extends ChecksBaseTest {
         assertThat(check.result()).isTrue();
     }
 
+    @Test
+    void shouldMatchExpression() { // checks whether the alternate constructor works
+        Check check = new MethodCalledInTestMethod("Utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isTrue();
+
+        check = new MethodCalledInTestMethod("MethodCalled.Utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isTrue();
+
+        check = new MethodCalledInTestMethod("utils", "fromString");
+        run("MethodCalled.java", check);
+        assertThat(check.result()).isFalse();
+    }
+
 }

--- a/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MethodCalledInTestMethodTest.java
@@ -24,10 +24,24 @@ public class MethodCalledInTestMethodTest extends ChecksBaseTest {
     }
 
     @Test
-    void shouldIgnoreAnonymousClasses() { // was breaking in midterm 2021
+    void shouldNotBreakWhenAnonymousClassesAreUsed() { // was breaking in midterm 2021
         Check check = new MethodCalledInTestMethod("getPoints");
         run("StackOverflowTestWithAnonymousClass.java", check);
         assertThat(check.result()).isTrue();
+    }
+
+    @Test
+    void shouldCheckForMethodCallsInsideAnonymousClasses() {
+        Check check = new MethodCalledInTestMethod("disableGravity");
+        run("StackOverflowTestWithAnonymousClass.java", check);
+        assertThat(check.result()).isTrue();
+    }
+
+    @Test
+    void shouldIgnoreAnnotationsInsideAnonymousClasses() {
+        Check check = new MethodCalledInTestMethod("fromString");
+        run("StackOverflowTestWithAnonymousClass.java", check);
+        assertThat(check.result()).isFalse();
     }
 
     @Test

--- a/andy/src/test/resources/codechecker/fixtures/MethodCalled.java
+++ b/andy/src/test/resources/codechecker/fixtures/MethodCalled.java
@@ -16,6 +16,10 @@ public class MethodCalled {
         void retrieve(){}
     }
 
+    class Utils {
+        int fromString(String x) { return 1; }
+    }
+
     @Test void t1() {
 
         SomeRepo repo = new SomeRepo();
@@ -33,5 +37,10 @@ public class MethodCalled {
     void t4() {
         SomeRepo repo = new SomeRepo();
         repo.retrieve();
+    }
+
+    @Test void t5() {
+        assertEquals(1, Utils.fromString("1"));
+        assertEquals(1, MethodCalled.Utils.fromString("1"));
     }
 }

--- a/andy/src/test/resources/codechecker/fixtures/StackOverflowTestWithAnonymousClass.java
+++ b/andy/src/test/resources/codechecker/fixtures/StackOverflowTestWithAnonymousClass.java
@@ -12,12 +12,19 @@ import org.junit.jupiter.params.*;
 import org.junit.jupiter.params.provider.*;
 
 class StackOverflowTest {
+    class Utils {
+        public void disableGravity() {}
+        public int fromString(String x) { return 1; }
+    }
+
     @Test
     void postFeaturedTest() {
 
         UserRepository userRepo = spy(new UserRepository() {
             @Override
-            public void update(User user) {}
+            public void update(User user) {
+                Utils.disableGravity();
+            }
         });
         Scoring score = mock(Scoring.class);
 
@@ -52,4 +59,21 @@ class StackOverflowTest {
         verify(userRepo).update(u);
         assertThat(u.getPoints()).isEqualTo(6);
     }
+
+    void notATest() {
+        UserRepository userRepo = spy(new UserRepository() {
+            @Override
+            public void update(User user) {}
+
+            @Test
+            public void testBogus() {
+                assertThat(Utils.fromString("1")).isEqualTo(1);
+            }
+        });
+        Scoring score = mock(Scoring.class);
+
+        StackOverflow sO = new StackOverflow(userRepo, score);
+    }
+
+
 }


### PR DESCRIPTION
MethodCalledInTestMethod currently only supports finding calls to methods with a specific name. In cases of methods like `of`, there could be many different classes that have this method (like `Arbitraries.of` and `List.of`), and it becomes impossible to exactly match the method calls that we want.

This pull request adds a way to match on the expression (the left hand side of the dot, e.g. `Arbitraries`). 

I am aware of the fact that the value of this is limited: if we wanted to forbid writing `Arbitraries.of`, one could easily write something like `(new Arbitraries()).of` (if there were such a public constructor) and therefore bypass the check.

I attempted to make this more robust by requesting the type bindings for the expression (and then match on that), but this does not always work. More specifically, it does not support nested calls like `user.name.toString()` (both the methods `resolveTypeBinding()` and `resolveMethodBinding` return `null` in that case). Therefore, checking for type bindings would give a false sense of security. Instead, we keep the functionality limited, and accept that this can only be used to do a basic check for the occurrence of calls like `Arbitraries.of`, and manual checking needs to be done to make 100% sure that nobody wrote their code incorrectly (which we were doing anyway).