### PR TITLE
Update to Java 23

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: 23
 
       - name: Cache Maven packages
@@ -45,7 +45,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: 23
 
       - name: Cache Maven packages
@@ -77,7 +77,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: 23
 
       - name: Cache Maven packages
@@ -109,7 +109,7 @@ jobs:
       - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
-          distribution: 'zulu'
+          distribution: 'corretto'
           java-version: 23
 
       - name: Cache Maven packages

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,11 +10,11 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -42,11 +42,11 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -74,11 +74,11 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v3
@@ -106,11 +106,11 @@ jobs:
       - name: Checkout the repository # Anchors not available in github actions :(
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 23
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 23
 
       - name: Cache Maven packages
         uses: actions/cache@v3

--- a/andy-aws-lambda/README.md
+++ b/andy-aws-lambda/README.md
@@ -5,7 +5,7 @@ You can deploy Andy to AWS lambda, so it gets easier for you to embedded it in a
 * Package this project, `mvn package`
 * Upload the .jar to S3
 * Create your AWS lambda function pointing to this jar
-* Pick Java 17 as runtime
+* Pick Java 23 as runtime
 * Define `nl.tudelft.cse1110.andy.aws.AndyOnAWSLambda::handleRequest` if you are going to use AWS API Gateway to expose the lambda as a HTTP service. Or `nl.tudelft.cse1110.andy.nl.tudelft.cse1110.andy.aws.AndyOnAWSLambda::run` in case you won't.
 * Call the API with the following JSON: 
 

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/engine/CheckScript.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/codechecker/engine/CheckScript.java
@@ -46,7 +46,7 @@ public class CheckScript {
         parser.setBindingsRecovery(true);
 
         Map<String, String> options = JavaCore.getOptions();
-        JavaCore.setComplianceOptions(JavaCore.VERSION_17, options);
+        JavaCore.setComplianceOptions(JavaCore.VERSION_23, options);
         parser.setCompilerOptions(options);
 
         parser.setEnvironment(new String[0], new String[0], null, true);

--- a/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/CompilationStep.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/execution/step/CompilationStep.java
@@ -79,7 +79,7 @@ public class CompilationStep implements ExecutionStep {
         }
     }
 
-    @SupportedSourceVersion(SourceVersion.RELEASE_14)
+    @SupportedSourceVersion(SourceVersion.RELEASE_23)
     @SupportedAnnotationTypes("*")
     public class ClassNameProcessor extends AbstractProcessor {
         private final ClassNameScanner scanner;

--- a/andy/src/test/java/unit/codechecker/JDTParser.java
+++ b/andy/src/test/java/unit/codechecker/JDTParser.java
@@ -17,7 +17,7 @@ public class JDTParser {
         parser.setBindingsRecovery(true);
 
         Map<String, String> options = JavaCore.getOptions();
-        JavaCore.setComplianceOptions(JavaCore.VERSION_17, options);
+        JavaCore.setComplianceOptions(JavaCore.VERSION_23, options);
         parser.setCompilerOptions(options);
 
         parser.setEnvironment(new String[0], new String[0], null, true);

--- a/assignments/pom.xml
+++ b/assignments/pom.xml
@@ -131,8 +131,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>23</source>
+                    <target>23</target>
                 </configuration>
             </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <maven.jar.plugin.version>3.4.2</maven.jar.plugin.version>
         <maven.shade.plugin>3.6.0</maven.shade.plugin>
 
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>23</maven.compiler.source>
+        <maven.compiler.target>23</maven.compiler.target>
         <project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 
         <andy.skipTests>false</andy.skipTests>
@@ -49,8 +49,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>17</source>
-                    <target>17</target>
+                    <source>23</source>
+                    <target>23</target>
 
                     <compilerArgs>
                         <arg>-XDcompilePolicy=simple</arg>

--- a/weblab-docker/Dockerfile
+++ b/weblab-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-amazoncorretto-17-debian
+FROM maven:3-amazoncorretto-23-debian
 
 WORKDIR /home/
 


### PR DESCRIPTION
Updated to Java 23. I ran tests locally and everything works without issues.

I also tested Java 21 (LTS) in the `java-21` branch. It also works, but I think it would be best to jump directly to 23 and update it to the next LTS version, which will be released in September 2025.