### PR TITLE
Remove incorrect meta test precondition

### DIFF
--- a/andy/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestsResult.java
+++ b/andy/src/main/java/nl/tudelft/cse1110/andy/result/MetaTestsResult.java
@@ -26,9 +26,6 @@ public class MetaTestsResult {
     }
 
     public MetaTestsResult addResults(int score, int totalTests, List<MetaTestResult> metaTestResults) {
-        if (metaTestResults.size() > totalTests)
-            throw new RuntimeException("Precondition failed: Number of meta tests does not match.");
-
         if (score > totalTests)
             throw new RuntimeException("Precondition failed: Meta test score greater than maximum.");
 

--- a/andy/src/test/java/integration/CodeChecksTest.java
+++ b/andy/src/test/java/integration/CodeChecksTest.java
@@ -43,6 +43,19 @@ public class CodeChecksTest extends IntegrationTestBase {
     }
 
     @Test
+    void zeroWeightCodeChecks() {
+        Result result = run( "SoftWhereLibrary", "SoftWhereTests", "SoftWhereConfigWithCodeChecksZeroWeight");
+
+        assertThat(result.hasGenericFailure()).isFalse();
+
+        assertThat(result)
+                .has(checksScore(0,0))
+                .has(codeCheck("Trip Repository should be mocked", true, 0))
+                .has(codeCheck("Trip should be mocked", false, 0)) // this check makes no sense, just for the check to fail
+                .has(codeCheck("getTripById should be set up", true, 0));
+    }
+
+    @Test
     void penaltyCodeChecksPass() {
         Result result = run( "SoftWhereLibrary", "SoftWhereTests", "SoftWhereConfigWithPenaltyCodeChecksPassingConfiguration");
 

--- a/andy/src/test/java/integration/LibraryMetaTestsTest.java
+++ b/andy/src/test/java/integration/LibraryMetaTestsTest.java
@@ -54,6 +54,22 @@ public class LibraryMetaTestsTest extends BaseMetaTestsTest {
     }
 
     @Test
+    void zeroWeightMetaTests() {
+        Result result = run("NumberUtilsAddLibrary", "NumberUtilsAddAllTestsPass", "NumberUtilsAddConfigurationWithZeroWeight");
+
+        assertThat(result.hasGenericFailure()).isFalse();
+
+        assertThat(result.getMetaTests().getTotalTests()).isEqualTo(0);
+        assertThat(result.getMetaTests().getPassedMetaTests()).isEqualTo(0);
+
+        assertThat(result.getMetaTests())
+                .has(passedMetaTest("DoesNotCheckNumbersOutOfRange"))
+                .has(failedMetaTest("AppliesMultipleCarriesWrongly"))
+                .has(failedMetaTest("DoesNotApplyCarryAtAll"))
+                .has(failedMetaTest("DoesNotApplyLastCarry"));
+    }
+
+    @Test
     void testMetaWhenMultipleClassesInLibrary() {
         Result result = run("SoftWhereLibrary", "SoftWhereMissingTests", "SoftWhereConfiguration");
 

--- a/andy/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithZeroWeight.java
+++ b/andy/src/test/resources/grader/fixtures/Config/NumberUtilsAddConfigurationWithZeroWeight.java
@@ -1,0 +1,100 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+import nl.tudelft.cse1110.andy.config.MetaTest;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 0.7f);
+            put("mutation", 0.3f);
+            put("meta", 0f);
+            put("codechecks", 0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.NumberUtils");
+    }
+
+    @Override
+    public List<MetaTest> metaTests() {
+        return List.of(
+            MetaTest.withStringReplacement(0, "AppliesMultipleCarriesWrongly",
+                """
+                int sum = leftDigit + rightDigit + carry;
+
+                result.addFirst(sum % 10);
+                carry = sum / 10;
+                """,
+                """
+                int sum;
+
+                if (leftDigit + rightDigit >= 10) {
+                    sum = leftDigit + rightDigit;
+                    carry = 1;
+                }
+                else {
+                    sum = leftDigit + rightDigit + carry;
+                    carry = 0;
+                }
+                result.addFirst(sum % 10);
+                """),
+            MetaTest.withLineReplacement(0, "DoesNotApplyCarryAtAll", 47, 68,
+                """
+                for (int i = 0; i < Math.max(reversedLeft.size(), reversedRight.size()); i++) {
+
+                    int leftDigit = reversedLeft.size() > i ? reversedLeft.get(i) : 0;
+                    int rightDigit = reversedRight.size() > i ? reversedRight.get(i) : 0;
+
+                    if (leftDigit < 0 || leftDigit > 9 || rightDigit < 0 || rightDigit > 9)
+                        throw new IllegalArgumentException();
+
+                    int sum = leftDigit + rightDigit;
+
+                    result.addFirst(sum % 10);
+                }
+
+                // remove leading zeroes from the result
+                while (result.size() > 1 && result.get(0) == 0)
+                    result.remove(0);
+
+                if (result.isEmpty()) {
+                    result.addFirst(0);
+                }
+
+                return result;
+                """),
+            MetaTest.withStringReplacement(0, "DoesNotApplyLastCarry",
+                """
+                // add leftover carry
+                result.addFirst(carry);
+
+                // remove leading zeroes from the result
+                while (result.size() > 1 && result.get(0) == 0)
+                    result.remove(0);
+
+                return result;
+                """,
+                """
+                // remove leading zeroes from the result
+                while (result.size() > 1 && result.get(0) == 0)
+                    result.remove(0);
+
+                if (result.isEmpty()) {
+                    result.addFirst(0);
+                }
+
+                return result;
+                """),
+            MetaTest.withLineReplacement(0, "DoesNotCheckNumbersOutOfRange", 52, 53, "")
+        );
+    }
+}

--- a/andy/src/test/resources/grader/fixtures/Config/SoftWhereConfigWithCodeChecksZeroWeight.java
+++ b/andy/src/test/resources/grader/fixtures/Config/SoftWhereConfigWithCodeChecksZeroWeight.java
@@ -1,0 +1,40 @@
+package delft;
+
+import nl.tudelft.cse1110.andy.codechecker.checks.Comparison;
+import nl.tudelft.cse1110.andy.codechecker.checks.MockClass;
+import nl.tudelft.cse1110.andy.codechecker.checks.MockitoWhen;
+import nl.tudelft.cse1110.andy.codechecker.engine.CheckScript;
+import nl.tudelft.cse1110.andy.codechecker.engine.SingleCheck;
+import nl.tudelft.cse1110.andy.config.RunConfiguration;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Configuration extends RunConfiguration {
+
+    @Override
+    public Map<String, Float> weights() {
+        return new HashMap<>() {{
+            put("coverage", 1f);
+            put("mutation", 0f);
+            put("meta", 0f);
+            put("codechecks", 0f);
+        }};
+    }
+
+    @Override
+    public List<String> classesUnderTest() {
+        return List.of("delft.SoftWhere");
+    }
+
+    @Override
+    public CheckScript checkScript() {
+        return new CheckScript(List.of(
+                new SingleCheck(0, "Trip Repository should be mocked", new MockClass("TripRepository")),
+                new SingleCheck(0, "Trip should be mocked", new MockClass("Trip")),
+                new SingleCheck(0, "getTripById should be set up", new MockitoWhen("getTripById", Comparison.GTE, 1))
+        ));
+    }
+
+}


### PR DESCRIPTION
Removed the incorrect precondition which would cause Andy to fail if all meta tests have a weight of 0.

Added integration tests for zero-weight meta tests and code checks.

Fixes #275