### PR TITLE
Add support for parameterless mock() invocations

### DIFF
--- a/andy/src/test/java/unit/codechecker/checks/MockClassTest.java
+++ b/andy/src/test/java/unit/codechecker/checks/MockClassTest.java
@@ -8,13 +8,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MockClassTest extends ChecksBaseTest {
-
     @ParameterizedTest
-    @CsvSource({"List,true", "Set,true", "Queue,true", "Deque,true", "HashMap,false"})
+    @CsvSource({"List,true", "Set,true", "ArrayList,true", "SortedMap, true", "Queue,true", "Deque,true", "HashMap,false"})
     void findMocks(String classToMock, boolean expectation) {
         Check check = new MockClass(classToMock);
         run("ManyMocks.java", check);
         assertThat(check.result()).isEqualTo(expectation);
     }
-
 }

--- a/andy/src/test/resources/codechecker/fixtures/ManyMocks.java
+++ b/andy/src/test/resources/codechecker/fixtures/ManyMocks.java
@@ -5,6 +5,7 @@ import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import java.util.Queue;
 import java.util.Deque;
@@ -36,6 +37,8 @@ public class ManyMocks {
     @Mock
     Deque<String> mockedDQ;
 
+    ArrayList arrayListT;
+
     @BeforeEach
     public void setup() {
         MockitoAnnotations.initMocks(this);
@@ -47,6 +50,10 @@ public class ManyMocks {
         List<String> mockedList = Mockito.mock(List.class);
         // with the static import
         Set<String> mockedSet = mock(Set.class);
+        // without specifying the class name (deriving from the type of the variable)
+        SortedMap<String, Integer> sortedMap = mock();
+        // without specifying the class name (deriving from the type of the variable), without an explicit type on the left
+        arrayListT = mock();
         // no mock
         HashMap<String, String> concreteHashMap = new HashMap<>();
     }

--- a/andy/src/test/resources/codechecker/fixtures/ManyMocks.java
+++ b/andy/src/test/resources/codechecker/fixtures/ManyMocks.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.Queue;
 import java.util.Deque;
 import java.util.SortedSet;
+import java.util.SortedMap;
 
 import static org.mockito.Mockito.mock;
 import org.mockito.MockitoAnnotations;


### PR DESCRIPTION
A student wrote this:

```java
class SecurityScannerTest {
    private SecurityOfficer securityOfficer;
    // ...

    private SecurityScanner scanner;

    @BeforeEach
    public void setUp() {
        securityOfficer = mock();
        // ...
    }
}
```

This is now valid Mockito syntax, so we want to make sure that we detect such a way to create a mock of a class (in this case the `SecurityOfficer` class).